### PR TITLE
hotfix:群晖7.1.1下载报错 #1139

### DIFF
--- a/resource/clients/synologyDownloadStation/init.js
+++ b/resource/clients/synologyDownloadStation/init.js
@@ -18,7 +18,7 @@
      */
     getSessionId() {
       return new Promise((resolve, reject) => {
-        let url = `${this.options.address}/webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login&account=${encodeURIComponent(this.options.loginName)}&passwd=${encodeURIComponent(this.options.loginPwd)}&session=DownloadStation&format=sid`;
+        let url = `${this.options.address}/webapi/auth.cgi?api=SYNO.API.Auth&version=6&method=login&account=${encodeURIComponent(this.options.loginName)}&passwd=${encodeURIComponent(this.options.loginPwd)}&session=DownloadStation&format=sid`;
         $.ajax({
           url,
           timeout: PTBackgroundService.options.connectClientTimeout,


### PR DESCRIPTION
按R酱说的把把 version=3 改成 version=6 能不能用，有群晖7.1.1的测试一下