### PR TITLE
fix: 修复两处等级条件显示的 bug

### DIFF
--- a/resource/sites/totheglory.im/config.json
+++ b/resource/sites/totheglory.im/config.json
@@ -87,14 +87,14 @@
     "level": "10", 
     "name": "NonaByte",
     "interval": "48",
-    "downloaded": "50TB",
+    "downloaded": "5TB",
     "ratio": "6.0",
     "privilege": "无"
   },{
     "level": "11", 
     "name": "DoggaByte",
     "interval": "48",
-    "downloaded": "100TB",
+    "downloaded": "10TB",
     "ratio": "6.0",
     "privilege": "无"
   }],

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -166,7 +166,7 @@
                 </template>
                 <div class="levelRequirement">
                   <template v-for="levelRequirement in props.item.levelRequirements">
-                    <template v-if="Number(props.item.user.nextLevel.level) > Number(levelRequirement.level)">
+                    <template v-if="!props.item.user.nextLevel.name || Number(props.item.user.nextLevel.level) > Number(levelRequirement.level)">
                       <v-icon small color="green darken-4">done</v-icon>
                     </template>
                     <template v-else>


### PR DESCRIPTION
1. 在支持等级条件显示的站点中，如果已经满级，那么所有等级的满足情况会全部显示不符合。原因是判断条件为“用户下一等级的level值是否超过当前等级的 level 值“，但是满级后没有”下一等级的 level 值“，因此导致判断失败。此修复在此条件上增加了”或下一等级名称不存在“。
2. ttg 的 NonaByte 和 DoggaByte 两个等级的下载量标准不正确，应为 5T 和 10T ，现在把上传量的 50T 和 100T 当成下载量标准了。