### PR TITLE
新增CG, TIK, HDB, KG, SDB, WiHD等级要求支持

### DIFF
--- a/resource/sites/cinemageddon.net/config.json
+++ b/resource/sites/cinemageddon.net/config.json
@@ -16,6 +16,24 @@
     "pages": ["/browse.php"],
     "scripts": ["/schemas/NexusPHP/common.js", "browse.js"]
   }],
+  "levelRequirements": [
+    {
+      "level": "1",
+      "name": "Power User",
+      "uploaded": "25GB",
+      "downloaded": "20GB",
+      "ratio": "1.2",
+      "privilege": "Maximum of 8 concurrent downloads"
+    },
+    {
+      "level": "2",
+      "name": "CG Superfan",
+      "uploaded": "200GB",
+      "downloaded": "20GB",
+      "ratio": "1.5",
+      "privilege": "Maximum of 12 concurrent downloads"
+    }
+  ],
   "searchEntryConfig": {
     "page": "/browse.php",
     "resultType": "html",

--- a/resource/sites/hdbits.org/config.json
+++ b/resource/sites/hdbits.org/config.json
@@ -16,7 +16,33 @@
     "scripts": ["/schemas/NexusPHP/common.js", "browse.js"]
   }],
   "host": "hdbits.org",
-  "searchEntryConfig": {
+  "levelRequirements": [
+    {
+      "level": "1",
+      "name": "1080i",
+      "interval": "4",
+      "downloaded": "30GB",
+      "ratio": "0.95",
+      "privilege": "You can view NFOs and request reseeds on poorly seeded torrents."
+    },
+    {
+      "level": "2",
+      "name": "1080p",
+      "interval": "4",
+      "downloaded": "500GB",
+      "ratio": "1.4",
+      "privilege": "As 1080i"
+    },
+    {
+      "level": "3",
+      "name": "UHD",
+      "interval": "4",
+      "downloaded": "500GB",
+      "ratio": "2.5",
+      "privilege": "As 1080i"
+    }
+  ],
+"searchEntryConfig": {
     "page": "/browse.php",
     "queryString": "search=$key$",
     "resultType": "html",

--- a/resource/sites/karagarga.in/config.json
+++ b/resource/sites/karagarga.in/config.json
@@ -17,7 +17,16 @@
     "pages": ["/browse.php"],
     "scripts": ["/schemas/NexusPHP/common.js", "browse.js"]
   }],
-  "searchEntryConfig": {
+  "levelRequirements": [
+    {
+      "level": "1",
+      "name": "Power User",
+      "interval": "13",
+      "uploaded": "50GB",
+      "ratio": "1.05"
+    }
+  ],
+"searchEntryConfig": {
     "page": "/browse.php",
     "queryString": "search=$key$&search_type=torrent",
     "resultType": "html",

--- a/resource/sites/sdbits.org/config.json
+++ b/resource/sites/sdbits.org/config.json
@@ -17,7 +17,33 @@
   }],
   "host": "sdbits.org",
   "collaborator": "luckiestone",
-  "searchEntryConfig": {
+  "levelRequirements": [
+    {
+      "level": "1",
+      "name": "DVD",
+      "interval": "4",
+      "downloaded": "30GB",
+      "ratio": "0.95",
+      "privilege": "Are able to leech 100 torrents at a time. You can view NFOs and request reseeds on poorly seeded torrents."
+    },
+    {
+      "level": "2",
+      "name": "SuperBit",
+      "interval": "4",
+      "downloaded": "500GB",
+      "ratio": "1.4",
+      "privilege": "As DVD"
+    },
+    {
+      "level": "3",
+      "name": "Criterion",
+      "interval": "4",
+      "downloaded": "500GB",
+      "ratio": "2.5",
+      "privilege": "As DVD"
+    }
+  ],
+"searchEntryConfig": {
     "page": "/browse.php",
     "queryString": "search=$key$",
     "resultType": "html",

--- a/resource/sites/world-in-hd.net/config.json
+++ b/resource/sites/world-in-hd.net/config.json
@@ -16,7 +16,30 @@
     "pages": ["/torrents"],
     "scripts": ["/schemas/NexusPHP/common.js", "browse.js"]
   }],
-  "searchEntryConfig": {
+  "levelRequirements": [
+    {
+      "level": "1",
+      "name": "720p",
+      "interval": "5",
+      "uploaded": "250GB",
+      "ratio": "2"
+    },
+    {
+      "level": "2",
+      "name": "1080i",
+      "interval": "15",
+      "uploaded": "400GB",
+      "ratio": "3"
+    },
+    {
+      "level": "3",
+      "name": "1080p",
+      "interval": "25",
+      "uploaded": "1.2TB",
+      "ratio": "4.5"
+    }
+  ],
+"searchEntryConfig": {
     "skipIMDbId": true,
     "page": "/torrent/ajaxsearchtorrent/$key$",
     "resultType": "html",

--- a/resource/sites/www.cinematik.net/config.json
+++ b/resource/sites/www.cinematik.net/config.json
@@ -16,6 +16,16 @@
     "pages": ["/browse.php"],
     "scripts": ["/schemas/NexusPHP/common.js", "browse.js"]
   }],
+  "levelRequirements": [
+    {
+      "level": "1",
+      "name": "Power User",
+      "interval": "8",
+      "uploaded": "100GB",
+      "ratio": "1.1",
+      "privilege": "More download slots"
+    }
+  ],
   "searchEntryConfig": {
     "page": "/browse.php",
     "resultType": "html",


### PR DESCRIPTION
- feat: 新增CG, TIK, HDB, KG, SDB, WiHD等级要求支持
顺便说明下适配过程中几个站点粗略统计的一些额外数据需求：
BTN: Snatch数，DIC/RED: Unique Group等， HDF: 不同下载量有不同的ratio要求，PTP: Upload数量