### PR TITLE
fix: 修复满级时不显示done状态图标的问题

### DIFF
--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -169,7 +169,6 @@
             {{ showUserLevel ? props.item.user.levelName : "****" }}
             <template v-if="showLevelRequirements">
               <template v-if="props.item.levelRequirements">
-                <template v-if="props.item.user.nextLevel">
                   <template v-if="props.item.user.nextLevel.name">
                     <div>
                       <v-icon small color="black darken-4">keyboard_tab</v-icon>
@@ -197,7 +196,6 @@
                       </template>
                     </div>
                   </template>
-                </template>
                 <template v-else>
                   <v-icon small color="green darken-4">done</v-icon>
                 </template>


### PR DESCRIPTION
-------

发现满级时不显示绿色的对勾状态图标，是多了一层判断，去除后显示正常。