### PR TITLE
fix(haidan): 修复读取等级积分带分号时识别错误的问题

### DIFF
--- a/resource/sites/www.haidan.video/config.json
+++ b/resource/sites/www.haidan.video/config.json
@@ -191,7 +191,7 @@
       "fields": {
         "classPoints": {
           "selector": ["a[href='classpoint.php']+span"],
-          "filters": ["query.text().trim()", "query ? parseInt(query) : 0"]
+          "filters": ["query.text().replace(/\\D/g,'')", "query ? parseInt(query) : 0"]
         }
       }
     }


### PR DESCRIPTION
-------

海胆的等级积分有千位分隔符，直接使用 parseInt 转换会丢失位数