### PR TITLE
fix(nexusphp): 修复 firefox 下部分站点解析不到入站日期的问题

### DIFF
--- a/resource/schemas/NexusPHP/config.json
+++ b/resource/schemas/NexusPHP/config.json
@@ -109,7 +109,7 @@
         },
         "joinTime": {
           "selector": ["td.rowhead:contains('加入日期')", "td.rowhead:contains('Join'):contains('date')"],
-          "filters": ["query.next().text().split(' (')[0]", "dateTime(query).isValid()?dateTime(query).valueOf():query"]
+          "filters": ["query.next().text().split(' (')[0].trim()", "dateTime(query).isValid()?dateTime(query).valueOf():query"]
         }
       }
     },


### PR DESCRIPTION
-------
发现 firefox 下读取不到 ssd 的入站时间，调试发现 firefox 下读取到的时间字符串比 chrome 的多一个空白行，尝试用 trim() 处理后正常。