### PR TITLE
style: Firefox extension id is not secret

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -34,7 +34,7 @@ jobs:
           timeoutMs: 600000
           zipFilePath: extension.zip
           xpiFilePath: artifact/extension.signed.xpi
-          extensionId: ${{ secrets.FF_EXT_UUID }}
+          extensionId: e9c422a1-5740-4c0a-a10e-867939119613
           jwtIssuer: ${{ secrets.FF_JWT_ISSUER }}
           jwtSecret: ${{ secrets.FF_JWT_SECRET }}
 


### PR DESCRIPTION
https://github.com/mozilla/policy-templates#extensionsettings

提前知道extension id可以方便Firefox policy部署，不然需要下载安装再去`about:support`里查看

