### PR TITLE
TL的分类比较特殊，搜索完全是字符串拼接而成

### DIFF
--- a/resource/sites/www.torrentleech.org/config.json
+++ b/resource/sites/www.torrentleech.org/config.json
@@ -47,7 +47,8 @@
     "scripts": ["/schemas/NexusPHP/common.js", "torrents.js"]
   }],
   "searchEntryConfig": {
-    "page": "/torrents/browse/list/query/$key$",
+    "page": "/torrents/browse/list/",
+    "appendString": "query/$key$",
     "resultType": "json",
     "parseScriptFile": "getSearchResult.js",
     "area": [{
@@ -59,6 +60,34 @@
   "searchEntry": [{
     "name": "all",
     "enabled": true
+  },{
+    "name": "Movies",
+    "appendString": "categories/8,9,11,37,43,14,12,13,47,15,29,36/query/$key$",
+    "enabled": false
+  },{
+    "name": "TV",
+    "appendString": "categories/26,32,27,44/query/$key$",
+    "enabled": false
+  },{
+    "name": "Games",
+    "appendString": "categories/17,42,19,21,39,22,30,48/query/$key$",
+    "enabled": false
+  },{
+    "name": "Apps",
+    "appendString": "categories/23,24,25,33/query/$key$",
+    "enabled": false
+  },{
+    "name": "Animation",
+    "appendString": "categories/34/query/$key$",
+    "enabled": false
+  },{
+    "name": "Books",
+    "appendString": "categories/45.46/query/$key$",
+    "enabled": false
+  },{
+    "name": "Music",
+    "appendString": "categories/31,16/query/$key$",
+    "enabled": false
   }],
   "selectors": {
     "userBaseInfo": {

--- a/src/background/searcher.ts
+++ b/src/background/searcher.ts
@@ -222,7 +222,6 @@ export class Searcher {
         }
 
         let queryString = entry.queryString;
-
         if (searchEntryConfigQueryString) {
           // 当前入口没有查询字符串时，尝试使用默认配置
           if (!queryString) {
@@ -268,11 +267,11 @@ export class Searcher {
             searchPage = (searchPage + "").substr(1);
           }
           let url: string = site.url + searchPage;
-
           if (queryString) {
             if (searchPage.indexOf("?") !== -1) {
               url += "&" + queryString;
-            } else {
+            } else if (searchEntryConfig && searchEntryConfig.appendString) { url += searchEntryConfig.appendString; }
+            else {
               url += "?" + queryString;
             }
           }

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -500,6 +500,7 @@ export interface SearchEntryConfig {
   requestMethod?: ERequestMethod;
   // 需要提交的数据
   requestData?: Dictionary<any>;
+  appendString?: string;
 }
 
 /**


### PR DESCRIPTION
https://github.com/pt-plugins/PT-Plugin-Plus/issues/1002
现有的page queryString等都需要 ? 或者 &拼接，没法实现

全部分类的搜索字符串为
/torrents/browse/list/frozen

分类的是
/torrents/browse/list/categories/31,16/query/frozen