### PR TITLE
feat:新增GT适配

### DIFF
--- a/resource/sites/gay-torrents.org/config.json
+++ b/resource/sites/gay-torrents.org/config.json
@@ -93,6 +93,9 @@
         },
         "seeding": {
           "selector": "#user_info span[title='Seed']"
+        },
+        "messageCount": {
+          "selector": "#my_menu > ul > li:contains('Mailbox') > span"
         }
       }
     },

--- a/resource/sites/gay-torrents.org/config.json
+++ b/resource/sites/gay-torrents.org/config.json
@@ -2,6 +2,7 @@
   "name": "GTorg",
   "timezoneOffset": "+0000",
   "url": "https://gay-torrents.org/",
+  "cdn": ["https://gay-torrents.se/", "https://gay-area.org/"],
   "icon": "https://gay-torrents.org/favicon.ico",
   "tags": ["影视", "成人", "综合"],
   "schema": "GTorg",

--- a/resource/sites/gay-torrents.org/config.json
+++ b/resource/sites/gay-torrents.org/config.json
@@ -1,0 +1,161 @@
+{
+  "name": "GTorg",
+  "timezoneOffset": "+0000",
+  "url": "https://gay-torrents.org/",
+  "icon": "https://gay-torrents.org/favicon.ico",
+  "tags": ["影视", "成人", "综合"],
+  "schema": "GTorg",
+  "host": "gay-torrents.org",
+  "collaborator": "davidxuang",
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "PowerUser",
+      "uploaded": "50 GB",
+      "ratio": "1.05",
+      "privilege": "Access to online users and tracker info"
+    },
+    {
+      "level": 2,
+      "name": "ExtraUser",
+      "uploaded": "250 GB",
+      "ratio": "2.00",
+      "privilege": "Access to online users, tracker info, requests, top 10 and users"
+    }
+  ],
+  "searchEntryConfig": {
+    "page": "/torrents_beta.php",
+    "queryString": "search=$key$&active=0&options=1",
+    "resultType": "html",
+    "parseScriptFile": "getSearchResult.js",
+    "resultSelector": ".torrentsContainer"
+  },
+  "searchEntry": [
+    {
+      "name": "all",
+      "enabled": false
+    },
+    {
+      "name": "misc",
+      "appendQueryString": "&category[]=17&category[]=31&category[]=49&category[]=41",
+      "enabled": true
+    },
+    {
+      "name": "Non-Porn",
+      "appendQueryString": "&category[]=41",
+      "enabled": false
+    },
+    {
+      "name": "Porn",
+      "appendQueryString": "&category[]=15&category[]=16&category[]=42&category[]=18&category[]=19&category[]=20&category[]=22&category[]=21&category[]=23&category[]=25&category[]=51&category[]=71&category[]=27&category[]=28&category[]=30&category[]=52&category[]=68&category[]=32&category[]=50&category[]=33&category[]=34&category[]=40&category[]=35&category[]=36&category[]=37&category[]=38&category[]=39",
+      "enabled": false
+    }
+  ],
+  "torrentTagSelectors": [
+    {
+      "name": "Free",
+      "selector": ".specsIn.Freee[title~='0%']",
+      "color": "blue"
+    },
+    {
+      "name": "50%",
+      "selector": ".specsIn.Freee[title~='50%']",
+      "color": "orange"
+    },
+    {
+      "name": "75%",
+      "selector": ".specsIn.Freee[title~='75%']",
+      "color": "lime darken-3"
+    },
+    {
+      "name": "Bumped",
+      "selector": ".specsIn.Bump",
+      "color": "grey"
+    }
+  ],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/index.php",
+      "fields": {
+        "id": {
+          "selector": "#my_menu > ul > li:first-child > a",
+          "attribute": "href",
+          "filters": ["query ? query.getQueryString('uid') : ''"]
+        },
+        "name": {
+          "selector": "#user_info li:has(i[title='Username'])",
+          "filters": ["query ? query.text().match(/\\s*(.+?)\\s*\\(/)[1] : ''"]
+        },
+        "bonus": {
+          "selector": "#user_info li:has(i[title~='Bonus'])",
+          "filters": ["query ? query.text().match(/[\\d.]+/)[0] : 0"]
+        },
+        "seeding": {
+          "selector": "#user_info span[title='Seed']"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/usercp.php?uid=$user.id$",
+      "fields": {
+        "name": {
+          "selector": ".simple_table.full_widths.left_column td:contains('User') + td"
+        },
+        "levelName": {
+          "selector": ".simple_table.full_widths.left_column td:contains('Rank') + td"
+        },
+        "uploaded": {
+          "selector": ".simple_table.full_widths.left_column td:contains('Uploaded') + td",
+          "filters": ["query.text().sizeToNumber()"]
+        },
+        "downloaded": {
+          "selector": ".simple_table.full_widths.left_column td:contains('Downloaded') + td",
+          "filters": ["query.text().sizeToNumber()"]
+        },
+        "joinTime": {
+          "selector": ".simple_table.full_widths.left_column td:contains('Joined') + td",
+          "filters": ["dateTime(query.text().replace(/(\\d{2})\\/(\\d{2})\\/(\\d{4})/,'$3-$2-$1')).valueOf()"]
+        }
+      }
+    }
+  },
+  "categories": [
+    {
+      "entry": "*",
+      "result": "&category[]=$id$",
+      "category": [
+        { "id": "15", "name": "Amateur" },
+        { "id": "16", "name": "Anal" },
+        { "id": "42", "name": "Animation" },
+        { "id": "18", "name": "Asian" },
+        { "id": "19", "name": "Bareback" },
+        { "id": "20", "name": "Bears" },
+        { "id": "22", "name": "Bisexual" },
+        { "id": "21", "name": "Black" },
+        { "id": "23", "name": "Chubs" },
+        { "id": "25", "name": "Cross Generation" },
+        { "id": "51", "name": "Doctor/Medical" },
+        { "id": "71", "name": "Fan Sites" },
+        { "id": "27", "name": "Fetish" },
+        { "id": "28", "name": "Group Sex" },
+        { "id": "30", "name": "Hunks" },
+        { "id": "52", "name": "Interracial" },
+        { "id": "68", "name": "Homo Erotic" },
+        { "id": "32", "name": "Latino" },
+        { "id": "50", "name": "Middle Eastern" },
+        { "id": "33", "name": "Military" },
+        { "id": "34", "name": "Oral-Sex" },
+        { "id": "40", "name": "Other" },
+        { "id": "35", "name": "Solo" },
+        { "id": "36", "name": "Trans" },
+        { "id": "37", "name": "Twinks" },
+        { "id": "38", "name": "Vintage" },
+        { "id": "39", "name": "Wrestling" },
+        { "id": "17", "name": "Applications" },
+        { "id": "31", "name": "Images" },
+        { "id": "49", "name": "Books" },
+        { "id": "41", "name": "Non-Porn" }
+      ]
+    }
+  ]
+}

--- a/resource/sites/gay-torrents.org/getSearchResult.js
+++ b/resource/sites/gay-torrents.org/getSearchResult.js
@@ -1,0 +1,94 @@
+(function (options, Searcher) {
+  class Parser {
+    constructor() {
+      this.haveData = false;
+      this.categories = {};
+      if (/Login/.test(options.responseText)) {
+        options.status = ESearchResultParseStatus.needLogin;
+        return;
+      }
+      options.isLogged = true;
+      this.haveData = true;
+    }
+
+    getResult() {
+      if (!this.haveData) {
+        return [];
+      }
+      let site = options.site;
+      let selector = options.resultSelector;
+      let table = options.page.find(selector);
+      let rows = table.find('> div.torrent');
+      if (rows.length == 0) {
+        options.status = ESearchResultParseStatus.torrentTableIsEmpty; //`[${options.site.name}]没有定位到种子列表，或没有相关的种子`;
+        return [];
+      }
+      let results = [];
+
+      try {
+        for (let index = 0; index < rows.length; index++) {
+          const row = rows.eq(index);
+
+          let title_elem = row.find('.torrent_link').first();
+          if (title_elem.length == 0) {
+            continue;
+          }
+
+          let comments = row.find('.downloadInfo > a:first-of-type').first().text().split(' ')[0]
+
+          let data = {
+            title: title_elem.text(),
+            link: `${site.url}${title_elem.attr('href')}`,
+            url: `${site.url}${row.find('.downloadLink').first().attr('href')}`,
+            size: row.find('.size').first().text(),
+            time: row.find('.date').first().text().replace(/\s*on\s*/, ''),
+            author: row.find('.uploader > span').first().text(),
+            seeders: row.find('.downloadPeers > div:first-child > a').first().text(),
+            leechers: row.find('.downloadPeers > div:last-child > a').first().text(),
+            completed: row.find('.downloadTimes').first().text().split(' ')[0],
+            comments: comments ? comments : 0,
+            site: site,
+            tags: this.getTags(row, options.torrentTagSelectors),
+            entryName: options.entry.name,
+            category: options.searcher.getCategoryById(
+              site,
+              options.url,
+              row.find('.categoryNew > a').first().attr('href').split('=')[1]
+            )
+          };
+          results.push(data);
+        }
+        if (results.length == 0) {
+          options.status = ESearchResultParseStatus.noTorrents;
+        }
+      } catch (error) {
+        console.log(error);
+        options.status = ESearchResultParseStatus.parseError;
+        options.errorMsg = error.stack;
+      }
+      return results;
+    }
+
+    getTags(row, selectors) {
+      let tags = [];
+      if (selectors && selectors.length > 0) {
+        selectors.forEach((item) => {
+          if (item.selector) {
+            let result = row.find(item.selector);
+            if (result.length) {
+              tags.push({
+                name: item.name,
+                color: item.color,
+              });
+            }
+          }
+        });
+      }
+      return tags;
+    }
+  }
+
+  let parser = new Parser(options);
+  options.results = parser.getResult();
+  console.log(options.results);
+})(options, Searcher);

--- a/resource/sites/www.gaytor.rent/config.json
+++ b/resource/sites/www.gaytor.rent/config.json
@@ -1,0 +1,165 @@
+{
+  "name": "GTru",
+  "timezoneOffset": "+0000",
+  "url": "https://www.gaytor.rent/",
+  "icon": "https://www.gaytor.rent/favicon.ico",
+  "tags": ["影视", "成人", "综合"],
+  "schema": "GTru",
+  "host": "www.gaytor.rent",
+  "collaborator": "davidxuang",
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "Power User",
+      "interval": "4",
+      "uploaded": "40 GB",
+      "ratio": "1.05"
+    }
+  ],
+  "searchEntryConfig": {
+    "page": "/search.php",
+    "queryString": "search=$key$&incldead=1&inname=1&indesc=1&infn=1&orderby=added&sort=desc",
+    "resultType": "html",
+    "parseScriptFile": "getSearchResult.js",
+    "resultSelector": "#mysearchtable",
+    "fieldSelector": {
+      "status": {
+        "selector": [".tocolsnatched", ".tocolloaded"],
+        "switchFilters": [["255"], ["3"]]
+      }
+    }
+  },
+  "searchEntry": [
+    {
+      "name": "all",
+      "enabled": false
+    },
+    {
+      "name": "misc",
+      "appendQueryString": "&c46=1&c50=1&c48=1&c58=1&c45=1&c1=1",
+      "enabled": true
+    },
+    {
+      "name": "Movies",
+      "appendQueryString": "&c45=1",
+      "enabled": false
+    },
+    {
+      "name": "TV",
+      "appendQueryString": "&c1=1",
+      "enabled": false
+    },
+    {
+      "name": "Porn",
+      "appendQueryString": "&c62=1&c29=1&c30=1&c43=1&c19=1&c17=1&c44=1&c9=1&c7=1&c5=1&c67=1&c66=1&c34=1&c68=1&c27=1&c32=1&c63=1&c12=1&c33=1&c53=1&c57=1&c35=1&c36=1&c37=1&c54=1&c38=1&c39=1&c56=1&c40=1&c47=1&c41=1&c42=1&c51=1&c65=1&c28=1",
+      "enabled": false
+    }
+  ],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/my.php",
+      "fields": {
+        "id": {
+          "selector": ".panel-title > a",
+          "attribute": "href",
+          "filters": ["query ? query.getQueryString('id') : ''"]
+        },
+        "name": {
+          "selector": ".panel-title > a"
+        },
+        "uploaded": {
+          "selector": ".nav:not(.navbar-right) > .navbar-text:first-of-type",
+          "filters": ["query ? query.text().replace(/.+UL:\\s*([\\d.]+ ?[A-Z]?i?B).+/gs, '$1').sizeToNumber() : null"]
+        },
+        "downloaded": {
+          "selector": ".nav:not(.navbar-right) > .navbar-text:first-of-type",
+          "filters": ["query ? query.text().replace(/.+DL:\\s*([\\d.]+ ?[A-Z]?i?B).*/gs, '$1').sizeToNumber() : null"]
+        },
+        "bonus": {
+          "selector": "#bonus"
+        },
+        "messageCount": {
+          "selector": "#unread"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "fields": {
+        "levelName": {
+          "selector": [
+            "img[src*='user.gif']",
+            "img[src*='power.gif']",
+            "img[src*='vip.gif']",
+            "img[src*='mod.gif']",
+            "img[src*='sysop.gif']",
+            "img[src*='admin.gif']"
+          ],
+          "attribute": "src",
+          "switchFilters": [["'User'"], ["'Power User'"], ["'VIP'"], ["'Moderator'"], ["'SysOp'"], ["'Admin'"]]
+        },
+        "joinTime": {
+          "selector": "td:contains('Join') + td",
+          "filters": ["dateTime(query.text().split(' (')[0]).valueOf()"]
+        },
+        "seedingSize": {
+          "selector": "#SeedingTorrents > div > table > tbody > tr:not(:first-of-type) > td:nth-of-type(3)",
+          "filters": ["jQuery.map(query, (item) => {return $(item).text()})", "_self.getTotalSize(query)"]
+        },
+        "seeding": {
+          "selector": "#SeedingTorrents > div > table > tbody > tr:not(:first-of-type)",
+          "filters": ["query.length"]
+        }
+      }
+    }
+  },
+  "categories": [
+    {
+      "entry": "*",
+      "result": "&c$id$=1",
+      "category": [
+        { "id": "62", "name": "Amateur" },
+        { "id": "29", "name": "Anal" },
+        { "id": "46", "name": "Anime & Games" },
+        { "id": "30", "name": "Asian" },
+        { "id": "43", "name": "Bareback" },
+        { "id": "19", "name": "BDSM" },
+        { "id": "17", "name": "Bears" },
+        { "id": "44", "name": "Black" },
+        { "id": "50", "name": "Books & Magazines" },
+        { "id": "9", "name": "Chubbies" },
+        { "id": "7", "name": "Clips" },
+        { "id": "48", "name": "Comic & Yaoi" },
+        { "id": "5", "name": "Daddies / Sons" },
+        { "id": "67", "name": "Dildos" },
+        { "id": "66", "name": "Fan Sites" },
+        { "id": "34", "name": "Fetish" },
+        { "id": "68", "name": "Fisting" },
+        { "id": "27", "name": "Grey / Older" },
+        { "id": "32", "name": "Group-Sex" },
+        { "id": "63", "name": "Homemade" },
+        { "id": "12", "name": "Hunks" },
+        { "id": "33", "name": "Images" },
+        { "id": "53", "name": "Interracial" },
+        { "id": "57", "name": "Jocks" },
+        { "id": "35", "name": "Latino" },
+        { "id": "36", "name": "Mature" },
+        { "id": "58", "name": "Media Programs" },
+        { "id": "37", "name": "Member" },
+        { "id": "54", "name": "Middle Eastern" },
+        { "id": "38", "name": "Military" },
+        { "id": "39", "name": "Oral-Sex" },
+        { "id": "56", "name": "Softcore" },
+        { "id": "40", "name": "Solo" },
+        { "id": "45", "name": "Themed Movie" },
+        { "id": "47", "name": "Trans" },
+        { "id": "1", "name": "TV / Episodes" },
+        { "id": "41", "name": "Twinks" },
+        { "id": "42", "name": "Vintage" },
+        { "id": "51", "name": "Voyeur" },
+        { "id": "65", "name": "Wrestling and Sports" },
+        { "id": "28", "name": "Youngblood" }
+      ]
+    }
+  ]
+}

--- a/resource/sites/www.gaytor.rent/config.json
+++ b/resource/sites/www.gaytor.rent/config.json
@@ -1,6 +1,6 @@
 {
   "name": "GTru",
-  "timezoneOffset": "+0000",
+  "timezoneOffset": "+0100",
   "url": "https://www.gaytor.rent/",
   "icon": "https://www.gaytor.rent/favicon.ico",
   "tags": ["影视", "成人", "综合"],

--- a/resource/sites/www.gaytor.rent/getSearchResult.js
+++ b/resource/sites/www.gaytor.rent/getSearchResult.js
@@ -1,0 +1,87 @@
+(function (options, Searcher) {
+  class Parser {
+    constructor() {
+      this.haveData = false;
+      this.categories = {};
+      if (/login\.php/.test(options.responseText)) {
+        options.status = ESearchResultParseStatus.needLogin;
+        return;
+      }
+      options.isLogged = true;
+      this.haveData = true;
+    }
+
+    getResult() {
+      if (!this.haveData) {
+        return [];
+      }
+      let site = options.site;
+      let selector = options.resultSelector;
+      let table = options.page.find(selector);
+      let rows = table.find('> tbody > tr');
+      if (rows.length <= 1) {
+        options.status = ESearchResultParseStatus.torrentTableIsEmpty; //`[${options.site.name}]没有定位到种子列表，或没有相关的种子`;
+        return [];
+      }
+      let results = [];
+      
+      try {
+        for (let index = 1; index < rows.length; index++) {
+          const row = rows.eq(index);
+
+          let title_elem = row.find('.torrent_title > .torrent_title').first();
+          if (title_elem.length == 0) {
+            continue;
+          }
+
+          let time = row.find('.tadded').first().text()
+          let peers = row.find('.hidden-xs.hidden-sm.biggerfont').first().text().match(/[\d,]+/g)
+          let comments = row.find('.tcomments').first().text().split(/\s/)[0];
+          let category = options.searcher.getCategoryById(
+            site,
+            options.url,
+            row.find('.browsemaincat > a').first().attr('href').split('=')[1]
+            )
+          let tags = []
+          if (row.find('.infocol > div[onmouseover] > font[color=yellow]').length > 0) {
+            tags.push({ name: 'Free', color: 'blue' })
+          }
+          if (title_elem.text().startsWith('♺')) {
+            tags.push({ name: 'Bumped', color: 'grey' })
+          }
+
+          let data = {
+            title: title_elem.text().replace(/^♺ /g, ''),
+            link: `${site.url}${title_elem.attr("href")}`,
+            url: `${site.url}${row.find('.index').first().attr('href')}&secure=1`,
+            size: row.find('.tsize').first().text(),
+            time: `${time.match(/\d{4}-\d{2}-\d{2}/g)[0]} ${time.match(/\d{2}:\d{2}:\d{2}/g)[0]}`,
+            author: '(Anonymous)',
+            seeders: peers[1],
+            leechers: peers[2],
+            completed: peers[0],
+            comments: comments ? comments : 0,
+            site: site,
+            tags: tags,
+            entryName: options.entry.name,
+            category: category.id ? category : { id: "-1", "name": "Porn" },
+            status: options.searcher.getFieldValue(site, row, "status")
+          };
+          results.push(data);
+        }
+        if (results.length == 0) {
+          options.status = ESearchResultParseStatus.noTorrents;
+        }
+      } catch (error) {
+        console.log(error);
+        options.status = ESearchResultParseStatus.parseError;
+        options.errorMsg = error.stack;
+      }
+      return results;
+    }
+  }
+
+  let parser = new Parser(options);
+  options.results = parser.getResult();
+  console.log(options.results);
+})(options, Searcher);


### PR DESCRIPTION
支持新站点。默认搜索模式（`misc`）不包括 NSFW 内容，以期符合默认全局搜索的需要。
* [GTru](https://www.gaytor.rent/)，新近由[旧域名](https://www.gaytorrent.ru/)迁移
  * Closes #664
* [GTorg](https://gay-torrents.org/)，并有[备用域名](https://gay-torrents.se/)
  * 相关 #202

# 截图
![图片](https://user-images.githubusercontent.com/24728204/210233223-2d0e4cfe-eabd-4717-85c7-2dd1cca73d31.png)
![图片](https://user-images.githubusercontent.com/24728204/210233743-c080f7ae-310e-4a1d-b1c0-1b07e1546341.png)

