### PR TITLE
feat(tjupt):增加升级条件

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -215,6 +215,7 @@
         "seedingSize": "Seeding size",
         "bonus": "Bonus",
         "seedingPoints": "Seeding Points",
+        "seedingTime": "Seeding Time",
         "bonusPerHour": "Bonus per hour",
         "joinTime": "Join time",
         "lastUpdateTime": "Update at",
@@ -223,6 +224,7 @@
         "uploaded": "Uploaded",
         "downloaded":"Downloaded",
         "uploads": "Uploaded",
+        "downloads": "Downloaded",
         "trueDownloaded": "True Downloaded",
         "classPoints": "Class Points",
         "alternative": "Alternative"

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -209,6 +209,7 @@
         "ratio": "分享率",
         "seeding": "做种数",
         "seedingSize": "做种体积",
+        "seedingTime": "做种时间",
         "bonus": "魔力值",
         "seedingPoints": "做种积分",
         "bonusPerHour": "时魔",
@@ -218,6 +219,7 @@
         "uploaded": "上传量",
         "downloaded":"下载量",
         "uploads": "发布",
+        "downloads": "完成",
         "trueDownloaded": "真实下载",
         "classPoints": "等级积分",
         "alternative": "择一"

--- a/resource/sites/tjupt.org/config.json
+++ b/resource/sites/tjupt.org/config.json
@@ -11,7 +11,95 @@
   ],
   "schema": "NexusPHP",
   "host": "tjupt.org",
-  "collaborator": "tongyifan",
+  "collaborator": ["tongyifan", "echo094"],
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "拜师学艺",
+      "interval": "4",
+      "downloads": "20",
+      "seedingTime": "30",
+      "uploaded": "50GB",
+      "bonus": "10000",
+      "privilege": "查看用户列表；请求续种；查看其他用户种子历史（隐私等级不为高时）；删除自己上传的字幕。"
+    },
+    {
+      "level": 2,
+      "name": "持剑下山",
+      "interval": "8",
+      "downloads": "60",
+      "seedingTime": "120",
+      "uploaded": "200GB",
+      "bonus": "30000",
+      "privilege": "封存账号后不会被删除。"
+    },
+    {
+      "level": 3,
+      "name": "初入江湖",
+      "interval": "16",
+      "downloads": "150",
+      "seedingTime": "450",
+      "uploaded": "800GB",
+      "uploads": "1",
+      "bonus": "80000",
+      "privilege": "首次升级至此等级时将获得1个永久邀请；发送邀请；做种/下载/发布时可以选择匿名。"
+    },
+    {
+      "level": 4,
+      "name": "小有名气",
+      "interval": "28",
+      "downloads": "300",
+      "seedingTime": "1500",
+      "uploaded": "2000GB",
+      "uploads": "5",
+      "bonus": "150000",
+      "privilege": "首次升级至此等级时将获得1个永久邀请；查看普通日志。"
+    },
+    {
+      "level": 5,
+      "name": "威震一方",
+      "interval": "48",
+      "downloads": "600",
+      "seedingTime": "4200",
+      "uploaded": "5000GB",
+      "uploads": "10",
+      "bonus": "300000",
+      "privilege": "首次升级至此等级时将获得1个永久邀请；查看其它用户的评论、帖子历史；永久保留账号。"
+    },
+    {
+      "level": 6,
+      "name": "横扫群雄",
+      "interval": "72",
+      "downloads": "1000",
+      "seedingTime": "28000",
+      "uploaded": "10000GB",
+      "uploads": "15",
+      "bonus": "400000",
+      "privilege": "首次升级至此等级时将获得1个永久邀请。"
+    },
+    {
+      "level": 7,
+      "name": "开宗立派",
+      "interval": "100",
+      "downloads": "1800",
+      "seedingTime": "90000",
+      "uploaded": "20000GB",
+      "uploads": "30",
+      "bonus": "600000",
+      "privilege": "首次升级至此等级时将获得2个永久邀请。"
+    },
+    {
+      "level": 8,
+      "name": "天下无敌",
+      "interval": "132",
+      "downloads": "3000",
+      "seedingTime": "300000",
+      "uploads": "50",
+      "uploaded": "50000GB",
+      "bonus": "1000000",
+      "privilege": "首次升级至此等级时将获得3个永久邀请。"
+    }
+  ],
   "searchEntry": [{
       "name": "全站",
       "enabled": true
@@ -161,6 +249,19 @@
         "seedingSize": {
           "selector": ["b:first"],
           "filters": ["$(query[0].nextSibling).text().trim().match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length==2)?(query[0]).sizeToNumber():0"]
+        }
+      }
+    },
+    "levelExtendInfo": {
+      "page": "/classes.php",
+      "fields": {
+        "downloads": {
+          "selector": ["#9 td:eq(1) li:eq(1)"],
+          "filters": ["parseInt(query.text().trim().split('：')[1].split('/')[0])"]
+        },
+        "seedingTime": {
+          "selector": ["#9 td:eq(1) li:eq(2)"],
+          "filters": ["parseFloat(query.text().trim().split('：')[1].split('/')[0])"]
         }
       }
     },

--- a/resource/sites/tjupt.org/config.json
+++ b/resource/sites/tjupt.org/config.json
@@ -262,6 +262,10 @@
         "seedingTime": {
           "selector": ["#9 td:eq(1) li:eq(2)"],
           "filters": ["parseFloat(query.text().trim().split('：')[1].split('/')[0])"]
+        },
+        "uploads": {
+          "selector": ["#9 td:eq(1) li:eq(4)"],
+          "filters": ["parseInt(query.text().trim().split('：')[1].split('/')[0])"]
         }
       }
     },

--- a/src/background/user.ts
+++ b/src/background/user.ts
@@ -204,7 +204,7 @@ export class User {
   public getMoreInfos(site: Site, userInfo: UserInfo): Promise<any> {
     return new Promise<any>((resolve?: any, reject?: any) => {
       let requests: any[] = [];
-      let selectors = ["userSeedingTorrents", "bonusExtendInfo", "hnrExtendInfo", "userUploadedTorrents"];
+      let selectors = ["userSeedingTorrents", "bonusExtendInfo", "hnrExtendInfo", "levelExtendInfo", "userUploadedTorrents"];
 
       selectors.forEach((name: string) => {
         let host = site.host as string;

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -282,6 +282,8 @@ export interface LevelRequirement {
   requiredDate?: string;
   // 上传数要求
   uploads?: number;
+  // 下载数要求
+  downloads?: number;
   // 上传量要求
   uploaded?: string | number;
   // 下载量要求
@@ -292,6 +294,8 @@ export interface LevelRequirement {
   bonus?: number;
   // 做种积分要求
   seedingPoints?: number;
+  // 做种时间要求
+  seedingTime?: number;
   // 保种体积要求
   seedingSize?: number;
   // 分享率要求
@@ -562,6 +566,8 @@ export interface UserInfo {
   downloaded?: number;
   // 真实下载量
   trueDownloaded?: string | number;
+  // 下载数
+  downloads?: number;
   // 分享率
   ratio?: number;
   // 当前做种数量
@@ -578,6 +584,8 @@ export interface UserInfo {
   bonus?: number;
   // 保种积分         //add by koal 220920
   seedingPoints?: number;
+  // 做种时间要求
+  seedingTime?: number;
   // 时魔
   bonusPerHour?: number;
   // 积分页面

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -657,7 +657,10 @@ export default Vue.extend({
             for (var levelRequirement of site.levelRequirements) {
               let nextLevel = this.calculateNextLeve(user, levelRequirement);
               if (nextLevel) {
-                user.nextLevels = [ nextLevel ];
+                if (user.nextLevels.length) {
+                  continue
+                }
+                user.nextLevels.push(nextLevel);
               } else {
                 user.nextLevels = []
               }

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -657,8 +657,9 @@ export default Vue.extend({
             for (var levelRequirement of site.levelRequirements) {
               let nextLevel = this.calculateNextLeve(user, levelRequirement);
               if (nextLevel) {
-                user.nextLevels.push(nextLevel);
-                break;
+                user.nextLevels = [ nextLevel ];
+              } else {
+                user.nextLevels = []
               }
             }
           }
@@ -676,6 +677,10 @@ export default Vue.extend({
 
       let downloaded = user.downloaded ?? 0;
       let uploaded = user.uploaded ?? 0;
+      
+      if (user.levelName == levelRequirement.name) {
+        return undefined;
+      }
 
       if (levelRequirement.interval && user.joinDateTime) {
         let weeks = levelRequirement.interval as number;

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -132,8 +132,17 @@
                             nextLevel.seedingPoints | formatNumber
                         }}&nbsp;
                       </template>
+                      <template v-if="nextLevel.seedingTime">
+                        <v-icon small color="green darken-4">timer</v-icon>{{
+                            nextLevel.seedingTime | formatNumber
+                        }}&nbsp;
+                      </template>
                       <template v-if="nextLevel.uploads">
                         <v-icon small color="green darken-4">file_upload</v-icon>{{ nextLevel.uploads
+                        }}&nbsp;
+                      </template>
+                      <template v-if="nextLevel.downloads">
+                        <v-icon small color="red darken-4">file_download</v-icon>{{ nextLevel.downloads
                         }}&nbsp;
                       </template>
                       <template v-if="nextLevel.classPoints">
@@ -168,6 +177,9 @@
                         {{ $t("home.levelRequirement.trueDownloaded") }}
                         {{ levelRequirement.trueDownloaded }};
                       </template>
+                      <template v-if="levelRequirement.downloads">
+                        <v-icon small color="red darken-4" :title="$t('home.levelRequirement.downloads')">file_download</v-icon>{{ levelRequirement.downloads }};
+                      </template>
                       <template v-if="levelRequirement.ratio">
                         <v-icon small color="orange darken-4" :title="$t('home.levelRequirement.ratio')">balance</v-icon>{{ levelRequirement.ratio }};
                       </template>
@@ -178,6 +190,11 @@
                       </template>
                       <template v-if="levelRequirement.seedingPoints">
                         <v-icon small color="green darken-4" :title="$t('home.levelRequirement.seedingPoints')">energy_savings_leaf</v-icon>{{ levelRequirement.seedingPoints
+                            | formatInteger
+                        }};
+                      </template>
+                      <template v-if="levelRequirement.seedingTime">
+                        <v-icon small color="green darken-4" :title="$t('home.levelRequirement.seedingTime')">timer</v-icon>{{ levelRequirement.seedingTime
                             | formatInteger
                         }};
                       </template>
@@ -204,6 +221,9 @@
                           {{ $t("home.levelRequirement.trueDownloaded") }}
                           {{ levelRequirement.alternative.trueDownloaded }};
                         </template>
+                        <template v-if="levelRequirement.alternative.downloads">
+                          <v-icon small color="red darken-4" :title="$t('home.levelRequirement.downloads')">file_download</v-icon>{{ levelRequirement.alternative.downloads }};
+                        </template>
                         <template v-if="levelRequirement.alternative.ratio">
                           <v-icon small color="orange darken-4" :title="$t('home.levelRequirement.ratio')">balance</v-icon>{{ levelRequirement.alternative.ratio }};
                         </template>
@@ -214,6 +234,11 @@
                         </template>
                         <template v-if="levelRequirement.alternative.seedingPoints">
                           <v-icon small color="green darken-4" :title="$t('home.levelRequirement.seedingPoints')">energy_savings_leaf</v-icon>{{ levelRequirement.alternative.seedingPoints
+                              | formatInteger
+                          }};
+                        </template>
+                        <template v-if="levelRequirement.alternative.seedingTime">
+                          <v-icon small color="green darken-4" :title="$t('home.levelRequirement.seedingTime')">timer</v-icon>{{ levelRequirement.alternative.seedingTime
                               | formatInteger
                           }};
                         </template>
@@ -708,11 +733,29 @@ export default Vue.extend({
         }
       }
 
+      if (levelRequirement.seedingTime) {
+        let userSeedingTime = user.seedingTime as number;
+        let requiredSeedingTime = levelRequirement.seedingTime as number;
+        if (userSeedingTime < requiredSeedingTime) {
+          nextLevel.seedingTime = requiredSeedingTime - userSeedingTime;
+          nextLevel.level = levelRequirement.level;
+        }
+      }
+
       if (levelRequirement.uploads) {
         let userUploads = user.uploads ? user.uploads as number : 0;
         let requiredUploads = levelRequirement.uploads as number;
         if (userUploads < requiredUploads) {
           nextLevel.uploads = requiredUploads - userUploads;
+          nextLevel.level = levelRequirement.level;
+        }
+      }
+
+      if (levelRequirement.downloads) {
+        let userDownloads = user.downloads ? user.downloads as number : 0;
+        let requiredDownloads = levelRequirement.downloads as number;
+        if (userDownloads < requiredDownloads) {
+          nextLevel.downloads = requiredDownloads - userDownloads;
           nextLevel.level = levelRequirement.level;
         }
       }


### PR DESCRIPTION
## 内容说明

增加北洋园(tjupt)的升级条件。

修改的内容：
1. LevelRequirement和UserInfo添加了完成种子数（downloads）和累计做种时间（seedingTime）这两个属性
2. 这两项信息通过页面`/classes.php`获取，参考PR  #1290 的做法添加了levelExtendInfo选择器
3. 修改`Home.vue`中的formatUserInfo和calculateNextLeve方法，通过比较名称实现对当前等级的判断

需要注意的内容：
* 升级条件中的H&R积分要求忽略
* 需要检查第三项修改是否对其它内容造成影响
