### PR TITLE
fix: 将传给Synology DownloadStation的下载任务附带正确的种子文件名

### DIFF
--- a/resource/clients/synologyDownloadStation/init.js
+++ b/resource/clients/synologyDownloadStation/init.js
@@ -17,6 +17,7 @@
     /**
      * 获取 SID
      */
+    // FIXME 这个方法已经不止获取SID了，CSRFToken也是在此获得，该考虑换个名字了
     getSessionId() {
       return new Promise((resolve, reject) => {
         let url = `${this.options.address}/webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login&account=${encodeURIComponent(this.options.loginName)}&passwd=${encodeURIComponent(this.options.loginPwd)}&session=DownloadStation&format=sid&enable_syno_token=yes`;
@@ -25,7 +26,6 @@
           timeout: PTBackgroundService.options.connectClientTimeout,
           dataType: "json"
         }).done((result) => {
-          console.log(result)
           if (result && result.success) {
             this.sessionId = result.data.sid;
             this.synoToken = result.data.synotoken

--- a/resource/clients/synologyDownloadStation/init.js
+++ b/resource/clients/synologyDownloadStation/init.js
@@ -147,10 +147,13 @@
 
         PTBackgroundService.requestMessage({
           action: "getTorrentDataFromURL",
-          data: options.url
+          data: {
+            url: options.url,
+            parseTorrent: true
+          }
         })
           .then((result) => {
-            formData.append("torrent", result, "file.torrent")
+            formData.append("torrent", result.content, `${result.torrent.name}.torrent`)
 
             this.addTorrent(formData, headers, options, callback);
           })

--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -927,7 +927,8 @@ export default class Controller {
               if (options.parseTorrent) {
                 resolve({
                   url,
-                  torrent
+                  torrent,
+                  content: file.content
                 });
               } else {
                 resolve(file.content);


### PR DESCRIPTION
## Start
挺老的一个issue了，一直还没解决。 关联issue：https://github.com/pt-plugins/PT-Plugin-Plus/issues/618

看了下现有过程，现在创建下载任务时调用的获取种子文件的方法没有直接返回种子对象本身（种子经过parse后拿到的结构化数据，以下都称之为torrent），只有content（种子的file blob，以下都称之为content）。

遂从后端入手，获取种子的方法在`src/background/controller.ts#881` ，该方法其实是有解析种子的参数，但如果将该参数置为true则不会返回种子的content（鱼和熊掌不可兼得是吧）
![图片](https://user-images.githubusercontent.com/6388562/218675825-367d6cfb-084e-4b48-a012-df953d06ead9.png)

于是决定扩展该方法，考虑到方法较为底层，所以改动的思路是影响范围尽可能小。于是分析该方法的过程中发现，如果入参`parseTorrent`为`false`时，resolve出去的则直接是content，没有经过任何对象的封装，如果需要追加返回torrent的话，势必改变出参的数据类型，这样改动影响范围太大，风险不可控。

而`parseTorrent`为`true`时，resove出去的数据经过对象封装，扩展字段很轻松，然后决定就干它了
![图片](https://user-images.githubusercontent.com/6388562/218678154-1bcd980b-945b-4aeb-87a9-9e0bd4a622c4.png)

根据调用链判断，该参数只被用在了`src/options/views/search/KeepUpload.vue#465`的`getTorrent`方法，查看上下文判断是辅种的搜索功能？辅种功能没用过，不能对改动进行测试，但考虑到仅仅在出参的对象中新增了一个key，应当不属于breakchange
![图片](https://user-images.githubusercontent.com/6388562/218674562-d8881539-cb75-48f2-9c49-b1c31e39ce53.png)

## End
新建的下载任务被附加了真实的filename，DownloadStation也可以正常查看
![图片](https://user-images.githubusercontent.com/6388562/218680554-b186dffb-69ec-453c-af1c-94ccd298bc76.png)



## BTW
感觉项目有点久了，很多实现和方法都很emmmmmm，维护起来确实有一些难度了

因为很难从全局角度去理解每一个模块和抽象的意义，所以这个PR的风险由你们来评估，我不确定实为了一个文件名就这么做是否真的足够优雅，甚至十分真的需要解决
