### PR TITLE
feat(dicmusic): 增加升级条件

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -227,6 +227,8 @@
         "downloads": "Downloaded",
         "trueDownloaded": "True Downloaded",
         "classPoints": "Class Points",
+        "uniqueGroups": "Unique Groups",
+        "perfectFLAC": "\"Perfect\" FLAC",
         "alternative": "Alternative"
       },
       "tip": "N/A means no support",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -222,6 +222,8 @@
         "downloads": "完成",
         "trueDownloaded": "真实下载",
         "classPoints": "等级积分",
+        "uniqueGroups": "独特分组",
+        "perfectFLAC": "“完美”FLAC",
         "alternative": "择一"
       },
       "tip": "N/A 表示暂不支持",

--- a/resource/schemas/GazelleJSONAPI/config.json
+++ b/resource/schemas/GazelleJSONAPI/config.json
@@ -59,6 +59,15 @@
         },
         "seeding": {
           "selector": ["response.community.seeding"]
+        },
+        "uploads": {
+          "selector": ["response.community.uploaded"]
+        },
+        "downloads": {
+          "selector": ["response.community.snatched"]
+        },
+        "uniqueGroups": {
+          "selector": ["response.community.groups"]
         }
       }
     },

--- a/resource/sites/dicmusic.club/config.json
+++ b/resource/sites/dicmusic.club/config.json
@@ -7,11 +7,97 @@
   "tags": ["音乐"],
   "schema": "GazelleJSONAPI",
   "host": "dicmusic.club",
-  "collaborator": ["ylxb2016", "enigmaz"],
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "Member",
+      "uploaded": "10GB",
+      "ratio": "0.7",
+      "interval": "1",
+      "privilege": "发起求种；查看部分排行榜；完全访问「茶话会」版块"
+    },
+    {
+      "level": 2,
+      "name": "Power User",
+      "uploaded": "25GB",
+      "ratio": "1.05",
+      "interval": "2",
+      "uploads": "5",
+      "privilege": "免疫账号不活跃；发送邀请，赠送1枚永久邀请；佩戴1枚印记；创建1个私人合集；访问「求邀区」「发邀区」「Power User」版块；完全访问排行榜"
+    },
+    {
+      "level": 3,
+      "name": "Elite",
+      "uploaded": "75GB",
+      "ratio": "1.05",
+      "interval": "4",
+      "uploads": "50",
+      "privilege": "赠送1枚永久邀请；佩戴2枚印记；创建2个私人合集；访问「Elite」版块；检查自己的种子；编辑所有种子；购买「自定义头衔（不允许 BBCode）」"
+    },
+    {
+      "level": 4,
+      "name": "Torrent Master",
+      "uploaded": "200GB",
+      "ratio": "1.05",
+      "interval": "8",
+      "uploads": "150",
+      "privilege": "赠送2枚永久邀请；每月1枚临时邀请；佩戴3枚印记；创建3个私人合集；访问「Torrent Master」版块"
+    },
+    {
+      "level": 5,
+      "name": "Power Torrent Master",
+      "uploaded": "375GB",
+      "ratio": "1.05",
+      "interval": "8",
+      "uniqueGroups": "300",
+      "privilege": "赠送2枚永久邀请；每月2枚临时邀请；佩戴4枚印记；创建4个私人合集；检查所有种子"
+    },
+    {
+      "level": 6,
+      "name": "Elite Torrent Master",
+      "uploaded": "600GB",
+      "ratio": "1.05",
+      "interval": "12",
+      "perfectFLAC": "500",
+      "privilege": "赠送3枚永久邀请；每月3枚临时邀请；无发邀间隔；佩戴5枚印记；创建5个私人合集；访问「Elite Torrent Master」版块"
+    },
+    {
+      "level": 7,
+      "name": "Elite Torrent Master Plus",
+      "uploaded": "600GB",
+      "ratio": "1.05",
+      "interval": "12",
+      "perfectFLAC": "500",
+      "privilege": "赠送3枚永久邀请；每月3枚临时邀请；购买「自定义头衔（允许 BBCode）」"
+    },
+    {
+      "level": 8,
+      "name": "Guru",
+      "uploaded": "1.2TB",
+      "ratio": "1.05",
+      "interval": "16",
+      "perfectFLAC": "1000",
+      "privilege": "拥有无限邀请；佩戴6枚印记；创建6个私人合集；访问「Guru」版块；查看种子检查日志"
+    }
+  ],
+  "collaborator": [
+    "ylxb2016",
+    "enigmaz",
+    "amorphobia"
+  ],
   "searchEntryConfig": {
     "skipIMDbId": true
   },
   "selectors": {
+    "userExtendInfo": {
+      "merge": true,
+      "page": "/ajax.php?action=user&id=$user.id$",
+      "fields": {
+        "perfectFLAC": {
+          "selector": ["response.community.perfectFlacs"]
+        }
+      }
+    },
     "userSeedingTorrents": {
       "page": "/bonus.php?action=bprates",
       "fields": {

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -302,6 +302,10 @@ export interface LevelRequirement {
   ratio?: number;
   // 等级积分要求
   classPoints?: number;
+  // 独特分组要求
+  uniqueGroups?: number;
+  // “完美”FLAC要求
+  perfectFLAC?: number;
   // 权限
   privilege?: string;
   // 可选要求
@@ -616,6 +620,10 @@ export interface UserInfo {
   lastErrorMsg?: string;
   // 消息数量
   messageCount?: number;
+  // 独特分组
+  uniqueGroups?: number;
+  // “完美”FLAC
+  perfectFLAC?: number;
   // 下一等级
   nextLevels?: LevelRequirement[];
   [key: string]: any;

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -145,6 +145,14 @@
                         <v-icon small color="red darken-4">file_download</v-icon>{{ nextLevel.downloads
                         }}&nbsp;
                       </template>
+                      <template v-if="nextLevel.uniqueGroups">
+                        <v-icon small color="green darken-4">library_music</v-icon>{{ nextLevel.uniqueGroups
+                        }}&nbsp;
+                      </template>
+                      <template v-if="nextLevel.perfectFLAC">
+                        <v-icon small color="green darken-4">diamond</v-icon>{{ nextLevel.perfectFLAC
+                        }}&nbsp;
+                      </template>
                       <template v-if="nextLevel.classPoints">
                         <v-icon small color="yellow darken-4">energy_savings_leaf</v-icon>{{
                             nextLevel.classPoints | formatNumber
@@ -203,6 +211,16 @@
                             | formatInteger
                         }};
                       </template>
+                      <template v-if="levelRequirement.uniqueGroups">
+                        <v-icon small color="green darken-4" :title="$t('home.levelRequirement.uniqueGroups')">library_music</v-icon>{{ levelRequirement.uniqueGroups
+                            | formatInteger
+                        }};
+                      </template>
+                      <template v-if="levelRequirement.perfectFLAC">
+                        <v-icon small color="green darken-4" :title="$t('home.levelRequirement.perfectFLAC')">diamond</v-icon>{{ levelRequirement.perfectFLAC
+                            | formatInteger
+                        }};
+                      </template>
                       <template v-if="levelRequirement.alternative">
                         <v-icon small :title="$t('home.levelRequirement.alternative')">filter_1</v-icon>(
                         <template v-if="levelRequirement.alternative.requiredDate">
@@ -244,6 +262,16 @@
                         </template>
                         <template v-if="levelRequirement.alternative.classPoints">
                           <v-icon small color="yellow darken-4" :title="$t('home.levelRequirement.classPoints')">energy_savings_leaf</v-icon>{{ levelRequirement.alternative.classPoints
+                              | formatInteger
+                          }};
+                        </template>
+                        <template v-if="levelRequirement.alternative.uniqueGroups">
+                          <v-icon small color="green darken-4" :title="$t('home.levelRequirement.uniqueGroups')">library_music</v-icon>{{ levelRequirement.alternative.uniqueGroups
+                              | formatInteger
+                          }};
+                        </template>
+                        <template v-if="levelRequirement.alternative.perfectFLAC">
+                          <v-icon small color="green darken-4" :title="$t('home.levelRequirement.perfectFLAC')">diamond</v-icon>{{ levelRequirement.alternative.perfectFLAC
                               | formatInteger
                           }};
                         </template>);
@@ -784,6 +812,24 @@ export default Vue.extend({
         let requiredClassPoints = levelRequirement.classPoints as number;
         if (userClassPoints < requiredClassPoints) {
           nextLevel.classPoints = requiredClassPoints - userClassPoints;
+          nextLevel.level = levelRequirement.level;
+        }
+      }
+
+      if (levelRequirement.uniqueGroups) {
+        let userUniqueGroups = user.uniqueGroups as number;
+        let requiredUniqueGroups = levelRequirement.uniqueGroups as number;
+        if (userUniqueGroups < requiredUniqueGroups) {
+          nextLevel.uniqueGroups = requiredUniqueGroups - userUniqueGroups;
+          nextLevel.level = levelRequirement.level;
+        }
+      }
+
+      if (levelRequirement.perfectFLAC) {
+        let userPerfectFLAC = user.perfectFLAC as number;
+        let requiredPerfectFLAC = levelRequirement.perfectFLAC as number;
+        if (userPerfectFLAC < requiredPerfectFLAC) {
+          nextLevel.perfectFLAC = requiredPerfectFLAC - userPerfectFLAC;
           nextLevel.level = levelRequirement.level;
         }
       }


### PR DESCRIPTION
## 说明
海豚的升级条件包含“独特分组”和“完美FLAC”两个数据，其中“独特分组”应该是 GazelleJSONAPI 站都有的数据，“完美FLAC”是音乐站有的数据。

### Level Requirement
- 在相关的代码中增加了“独特分组(uniqueGroups)”和“完美FLAC(perfectFLAC)”，参考了 #1318 的代码

### GazelleJSONAPI
- 增加了“独特分组(uniqueGroups)”、“发布数(uploads)”和“下载数(downloads)”的获取

### dicmusic
- 增加了“完美FLAC(perfectFLAC)”的获取
- 增加了升级条件

#### Elite Torrent Master 和 Elite Torrent Master Plus
海豚用户等级中，这两个级别的要求几乎一样，只是 Elite Torrent Master 对于“完美FLAC”的数量可以包含 WAV 和 DSD 格式，而 Elite Torrent Master Plus 只能是 FLAC 格式，但出于以下几点，在代码里的要求是完全一样的：

1. API 无法简单获取 WAV 和 DSD 数量
2. 站点鼓励 FLAC，WAV 不再记入“完美”
3. DSD 格式实际数量相当少，全站只有几十个

因此对于大多数用户，这两个级别的升级条件可以认为是相同的