### PR TITLE
fix(SSD): 搜索结果副标题匹配 #1350

### DIFF
--- a/resource/sites/springsunday.net/config.json
+++ b/resource/sites/springsunday.net/config.json
@@ -176,6 +176,10 @@
   }],
   "searchEntryConfig": {
     "fieldSelector": {
+      "subTitle": {
+        "selector": ["div.torrent-smalldescr:first"],
+        "filters": ["query.prop('lastChild').nodeValue.trim()"]
+      },
       "progress": {
         "selector": ["a[id*='subscription'] > img"],
         "filters": ["query.is('.uploading') ? 100 : query.is('.downloading') ? query.attr('title').match(/(\\d.+)%/)[1] : null"]


### PR DESCRIPTION
## 说明
修改站点的`config.json`匹配副标题
<img width="1003" alt="图片" src="https://user-images.githubusercontent.com/7688350/219909675-95a718f3-19d4-46a1-8582-fb5ab016dfcf.png">
