### PR TITLE
fix: Update anchor style for dark theme

### DIFF
--- a/src/options/views/search/SearchTorrent.scss
+++ b/src/options/views/search/SearchTorrent.scss
@@ -56,7 +56,7 @@
     color: #008c00;
   }
 
-  .theme--dark a {
+  .theme--dark a:hover {
     color: #ff73ff;
   }
 


### PR DESCRIPTION
Make dark theme text white on black, and purple when hovered.