### PR TITLE
feat: 添加种子时, 按站点设置自动限速

### DIFF
--- a/resource/clients/qbittorrent/init.js
+++ b/resource/clients/qbittorrent/init.js
@@ -173,6 +173,10 @@
         formData.append("tags", data.imdbId);
       }
 
+      if (data.upLoadLimit && data.upLoadLimit > 0) {
+        formData.append("upLimit", data.upLoadLimit);
+      }
+
       let url = data.url;
 
       // 磁性连接

--- a/resource/clients/qbittorrent/init.js
+++ b/resource/clients/qbittorrent/init.js
@@ -174,7 +174,7 @@
       }
 
       if (data.upLoadLimit && data.upLoadLimit > 0) {
-        formData.append("upLimit", data.upLoadLimit);
+        formData.append("upLimit", data.upLoadLimit * 1024);
       }
 
       let url = data.url;

--- a/resource/clients/transmission/init.js
+++ b/resource/clients/transmission/init.js
@@ -6,7 +6,7 @@
   class Transmission {
     /**
      * 初始化实例
-     * @param {*} options 
+     * @param {*} options
      * loginName: 登录名
      * loginPwd: 登录密码
      * url: 服务器地址
@@ -56,7 +56,7 @@
           case "addTorrentFromURL":
             this.addTorrentFromUrl(data.url, data.savePath, data.autoStart, (result) => {
               resolve(result);
-            });
+            }, data.upLoadLimit);
             break;
 
             // 获取可用空间
@@ -82,9 +82,9 @@
 
     /**
      * 调用指定的RPC
-     * @param {*} options 
-     * @param {*} callback 
-     * @param {*} tags 
+     * @param {*} options
+     * @param {*} callback
+     * @param {*} tags
      */
     exec(options, callback, tags) {
       return new Promise((resolve, reject) => {
@@ -145,9 +145,9 @@
 
     /**
      * 发送请求
-     * @param {*} options 
-     * @param {*} success 
-     * @param {*} error 
+     * @param {*} options
+     * @param {*} success
+     * @param {*} error
      */
     sendRequest(options, success, error) {
       $.ajax(options).done((resultData, textStatus) => {
@@ -182,7 +182,7 @@
      * @param bool autoStart 是否自动开始
      * @param function callback 回调
      */
-    addTorrentFromUrl(url, savePath, autoStart, callback) {
+    addTorrentFromUrl(url, savePath, autoStart, callback, uploadLimit = 0) {
       var options = {
         method: "torrent-add",
         arguments: {
@@ -193,6 +193,10 @@
 
       if (savePath) {
         options.arguments["download-dir"] = savePath;
+      }
+
+      if (uploadLimit && uploadLimit > 0) {
+        options.arguments["uploadLimit"] = uploadLimit;
       }
 
       // 磁性连接
@@ -231,8 +235,8 @@
 
     /**
      * 添加种子
-     * @param {*} options 
-     * @param {*} callback 
+     * @param {*} options
+     * @param {*} callback
      */
     addTorrent(options, callback) {
       this.exec(options).then((data) => {

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -717,8 +717,8 @@
           "priorityTip": "Can be used for search sorting",
           "offline": "Site is offline (downtime\/shutdown)",
           "timezone": "Timezone",
-          "upLoadLimit": "Upload limit (B\/s)",
-          "upLoadLimitTip": "Upload limit (B\/s), 0 for no limit",
+          "upLoadLimit": "Upload limit",
+          "upLoadLimitTip": "Upload limit (KB\/s), 0 or empty for no limit",
           "disableMessageCount": "Display message count"
         },
         "userinfo": {

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -717,6 +717,8 @@
           "priorityTip": "Can be used for search sorting",
           "offline": "Site is offline (downtime\/shutdown)",
           "timezone": "Timezone",
+          "upLoadLimit": "Upload limit (B\/s)",
+          "upLoadLimitTip": "Upload limit (B\/s), 0 for no limit",
           "disableMessageCount": "Display message count"
         },
         "userinfo": {

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -712,6 +712,8 @@
           "priorityTip": "可用于搜索排序",
           "offline": "站点已离线（停机/关闭）",
           "timezone": "时区",
+          "upLoadLimit": "上传速度限制",
+          "upLoadLimitTip": "上传速度限制 (B/s), 0 不限速",
           "disableMessageCount": "关闭消息提醒"
         },
         "userinfo": {

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -713,7 +713,7 @@
           "offline": "站点已离线（停机/关闭）",
           "timezone": "时区",
           "upLoadLimit": "上传速度限制",
-          "upLoadLimitTip": "上传速度限制 (B/s), 0 不限速",
+          "upLoadLimitTip": "上传速度限制 (KB/s), 0或不填 不限速",
           "disableMessageCount": "关闭消息提醒"
         },
         "userinfo": {

--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -255,6 +255,10 @@ export default class Controller {
     downloadOptions: DownloadOptions,
     host: string = ""
   ): Promise<any> {
+    // copy from sendTorrentToDefaultClient
+    let URL = Filters.parseURL(downloadOptions.url);
+    let downloadHost = URL.host;
+    let siteConfig = this.getSiteFromHost(downloadHost);
     return new Promise((resolve?: any, reject?: any) => {
       clientConfig.client
         .call(EAction.addTorrentFromURL, {
@@ -265,6 +269,7 @@ export default class Controller {
               ? false
               : downloadOptions.autoStart,
           imdbId: downloadOptions.tagIMDb ? downloadOptions.imdbId : null,
+          upLoadLimit: siteConfig.upLoadLimit,
         })
         .then((result: any) => {
           this.service.logger.add({

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -271,6 +271,7 @@ export interface Site {
   disableMessageCount?: boolean;
   // 等级要求
   levelRequirements?: LevelRequirement[];
+  upLoadLimit?: number;
 }
 
 export interface LevelRequirement {

--- a/src/options/views/settings/Sites/Editor.vue
+++ b/src/options/views/settings/Sites/Editor.vue
@@ -136,6 +136,13 @@
           </template>
         </v-autocomplete>
 
+        <v-text-field
+                v-model="site.upLoadLimit"
+                :label="$t('settings.sites.editor.upLoadLimit')"
+                :placeholder="$t('settings.sites.editor.upLoadLimitTip')"
+                required
+                :rules="rules.require"
+        ></v-text-field>
         <!-- 允许获取用户信息 -->
         <v-switch
           :label="$t('settings.sites.editor.allowGetUserInfo')"


### PR DESCRIPTION
## 添加种子时, 按站点设置自动限速
* 添加种子时, 按站点设置自动限速
* 因为时间有限且tr适配方式和 qb 应该差不多，所以目前只适配了 QB
## 参考文档
https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#add-new-torrent
https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#32-torrent-mutator-torrent-set
https://github.com/pt-plugins/PT-Plugin-Plus/wiki/developer
## 结果
### 限速前
* 限速设置可以在站点界面添加(已测试) 也可以在 site 的 config.json 中预设.(未测试)

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/089fc79e-3aaa-4fc6-b09f-ac0c2c192c47)
### 限速后
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/d0f49efe-37a0-4c7a-a5e1-23c3bdab87ac)
### 设置位置
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/05e84585-b1d4-4c19-84ff-35b0a85d7adb)
## issues
#1421 #145 #317 #1030

> ~~自己 PR 就什么都有了~~  
