### PR TITLE
fix(红叶): 忽略红叶用户名最后的枫叶图标

### DIFF
--- a/resource/sites/leaves.red/config.json
+++ b/resource/sites/leaves.red/config.json
@@ -6,7 +6,7 @@
   "tags": ["有声书", "综合"],
   "schema": "NexusPHP",
   "host": "leaves.red",
-  "collaborator": "CosmoGao",
+  "collaborator": ["CosmoGao", "tedzhu"],
   "plugins": [
     {
         "isCustom": true,
@@ -103,6 +103,15 @@
   ],
   "selectors": {
     "merge": true,
+    "userBaseInfo": {
+      "merge": true,
+      "fields": {
+        "name": {
+          "selector": ["a[href*='userdetails.php'][class*='Name']:first"],
+          "filters": ["query[0].firstChild.firstChild.nodeValue"]
+        }
+      }
+    },
     "userSeedingTorrents": {
       "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
       "fields": {


### PR DESCRIPTION
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/484992/d8a73feb-facb-47da-86e8-67807fbc8b25)
红叶用户名后面有一个枫叶图标会在PTPP中被识别成一个特殊字符。