### PR TITLE
feat: add new tracker nCore

### DIFF
--- a/resource/sites/ncore.pro/config.json
+++ b/resource/sites/ncore.pro/config.json
@@ -1,0 +1,85 @@
+{
+  "name": "nCore",
+  "timezoneOffset": "+0000",
+  "description": "nCore",
+  "url": "https://ncore.pro/",
+  "icon": "https://ncore.pro/favicon.ico",
+  "tags": ["影视", "综合"],
+  "schema": "nCore",
+  "collaborator": "gawain",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/torrents.php?action=details&id=\\d+"],
+    "scripts": ["/schemas/NexusPHP/common.js", "details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/torrents.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "torrents.js"]
+  }],
+  "host": "ncore.pro",
+  "searchEntryConfig": {
+    "page": "/torrents.php",
+    "queryString": "search=$key$&cat=0&searchin=1&sort=2",
+    "resultType": "html",
+    "parseScriptFile": "getSearchResult.js",
+    "resultSelector": "div.visitedlinks:last > div[class=torrentrow]"
+  },
+  "searchEntry": [{
+    "name": "All",
+    "enabled": true
+  }],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/index.php",
+      "fields": {
+        "id": {
+          "selector": "#confg",
+          "attribute": "data-uid"
+        },
+        "name": {
+          "selector": "#infosav_adatok a:first-child"
+        },
+        "isLogged": {
+          "selector": ["a[href*='exit.php']"],
+          "filters": ["query.length>0"]
+        },
+        "messageCount": {
+          "selector": [".alert a[href*='inbox.php']"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/profile.php?id=$user.id$",
+      "fields": {
+        "levelName": {
+	        "selector": ["div#infosav_adatok"],
+          "filters": ["query.text().match(/\\((.*?)\\)/)[1]"]
+	        },
+          "uploaded": {
+            "selector": ["span.list_alert"],
+            "filters": ["query.text().replace(/,/g,'').sizeToNumber()"]
+          },
+          "downloaded": {
+            "value": 0
+            },
+        
+    	  "bonus": {
+          "selector": ["div.profil_jobb_elso2:contains('Pontok száma:') + div.profil_jobb_masodik2"],
+          "filters": ["query.text().replace(/,/g, '')"]
+    	    },
+	      "joinTime": {
+          "selector": ["div.profil_jobb_masodik2 > span"],
+          "filters": ["query.attr('title') || query.text()", "dateTime(query).isValid() ? dateTime(query).valueOf() : query"]
+	        },
+        "seeding": {
+	        "selector": ["div.lista_mini_fej"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=1)?query[0]:''"]
+	      },
+        "seedingSize": {
+	        "value": -1
+	      }
+    }
+    }
+  }
+}

--- a/resource/sites/passthepopcorn.me/config.json
+++ b/resource/sites/passthepopcorn.me/config.json
@@ -14,6 +14,54 @@
     "parseScriptFile": "getSearchResult.js",
     "queryString": "searchstr=$key$&grouping=0&inallakas=1&json=noredirect"
   },
+   "levelRequirements": [{
+                "level": "1",
+                "name": "Member",
+                "interval": "1",
+                "ratio":"0.8",
+                "uploaded": "40GiB",
+                "privilege": "create requests"
+              },{
+                "level": "2",
+                "name": "Power User",
+                "interval": "4",
+                "ratio":"1.05",
+                "uploaded": "80GiB",
+                "uploads": "1",
+                "privilege": "Power Users have access to the Power User and Invite forums. They are immune to inactivity pruning."
+              },{
+                "level": "3",
+                "name": "Elite",
+                "interval": "10",
+                "ratio":"1.05",
+                "uploaded": "500GiB",
+                "uploads": "50",
+                "privilege": "Can access the Elite forums. They may purchase invites from the bonus store."
+              },{
+                "level": "4",
+                "name": "Torrent Master",
+                "interval": "16",
+                "ratio":"1.05",
+                "uploaded": "1TiB",
+                "uploads": "200",
+                "privilege": "Can access the Torrent Master forums. They also receive 2 invites a month. (Limited at 4 invites)"
+              },{
+                "level": "5",
+                "name": "Torrent King",
+                "interval": "24",
+                "ratio":"1.05",
+                "uploaded": "5TiB",
+                "uploads": "500",
+                "privilege": "create personal collections to feature on their profiles. double posting in the forum. unlimited search and log results."
+              },{
+                "level": "6",
+                "name": "Custom Class",
+                "interval": "36",
+                "ratio":"1.05",
+                "uploaded": "10TiB",
+                "uploads": "1000",
+                "privilege": "Choosing their own class title (subject to staff approval)."
+   }],
   "searchEntry": [{
     "name": "Normal",
     "enabled": true
@@ -53,6 +101,10 @@
           "selector": ["a.user-info-bar__link[href*='type=seeding']:first"],
           "filters": ["query.attr('title').replace(/,/g,'').sizeToNumber()"]
         },
+	 "uploads": {
+          "selector": ["span[title='The parentheses contains the number of the uploads including the deleted torrents.']"],
+          "filters": ["query.text().match(/\\d+/)","query ? parseFloat(query[0].replace(/,/g, '')) : 0"]
+        },
         "downloaded": {
           "selector": ["a.user-info-bar__link[href*='type=leeching']:first"],
           "filters": ["query.attr('title').replace(/,/g,'').sizeToNumber()"]
@@ -76,6 +128,10 @@
         "bonus": {
           "selector": ["ul.list > li:contains('Points:')", "div:contains('Stats') + ul.stats > li:contains('SeedBonus:')"],
           "filters": ["query.text().replace(/,|\\n|\\s+/g,'')", "query.match(/Points.+?([\\d.]+)/)||query.match(/SeedBonus.+?([\\d.]+)/)", "(query && query.length>=2)?query[1]:0"]
+        },
+	"bonusPerHour": {
+	  "selector": ["li:contains('Points per hour:')"],
+          "filters": ["query.text().replace(/,/g, '').match(/\\d+/)","query ? parseFloat(query[0]) : 0"]
         },
         "joinTime": {
           "selector": ["ul.list > li:contains('Joined:') > span"],


### PR DESCRIPTION

- feat: 增加nCore的数据显示

## 内容说明
简单添加了这个站数据 包括名字等级上传魔力入站时间等数据，ratioless没有下载

但搜索、种子推送还有待支持
