### PR TITLE
Fix: levelRequirement.level部分站点为字符串，未转换为数字导致站点状态判断错误

### DIFF
--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -718,13 +718,13 @@ export default Vue.extend({
           for (var levelRequirement of site.levelRequirements) {
             if (user.levelName?.trim()?.toUpperCase() == levelRequirement.name?.trim()?.toUpperCase())
             {
-              userLevel = levelRequirement.level as number;
+              userLevel = Number(levelRequirement.level);
               break;
             }
           }
 
           for (var levelRequirement of site.levelRequirements) {
-            if (levelRequirement.level as number < userLevel)
+            if (Number(levelRequirement.level) < userLevel)
               continue;
 
             if (levelRequirement.alternative)


### PR DESCRIPTION
<img width="855" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/2724562/7fa19fd7-f90f-4a3b-8a9a-3ed7ceb86241">
<img width="644" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/2724562/ab018d7e-b765-4f6b-a9d7-bf5f5b652d98">
本地调试as number并没有把level转换为number，依然在用字符串判断，导致ttg这种level大于10的判断错误