### PR TITLE
feat(#974): 支持禁用部分下载客户端

### DIFF
--- a/resource/clients/deluge/config.json
+++ b/resource/clients/deluge/config.json
@@ -1,5 +1,6 @@
 {
   "name": "Deluge",
+  "enabled": true,
   "type": "deluge",
   "ver": "0.0.1",
   "icon": "https://www.deluge-torrent.org/images/deluge-icon.png",

--- a/resource/clients/flood/config.json
+++ b/resource/clients/flood/config.json
@@ -1,5 +1,6 @@
 {
   "name": "Flood",
+  "enabled": true,
   "type": "flood",
   "ver": "0.0.1",
   "icon": "https://github.com/Flood-UI/flood/raw/master/flood.png",

--- a/resource/clients/qbittorrent/config.json
+++ b/resource/clients/qbittorrent/config.json
@@ -1,5 +1,6 @@
 {
   "name": "qBittorrent",
+  "enabled": true,
   "type": "qbittorrent",
   "ver": "0.0.1",
   "icon": "https://www.qbittorrent.org/favicon.ico",

--- a/resource/clients/ruTorrent/config.json
+++ b/resource/clients/ruTorrent/config.json
@@ -1,5 +1,6 @@
 {
   "name": "ruTorrent",
+  "enabled": true,
   "type": "ruTorrent",
   "ver": "0.0.1",
   "icon": "https://raw.githubusercontent.com/Novik/ruTorrent/master/images/favicon.ico",

--- a/resource/clients/synologyDownloadStation/config.json
+++ b/resource/clients/synologyDownloadStation/config.json
@@ -1,5 +1,6 @@
 {
   "name": "Synology Download Station",
+  "enabled": true,
   "type": "synologyDownloadStation",
   "ver": "0.0.1",
   "icon": "https://www.synology.com/img/icon/favicon.png",

--- a/resource/clients/transmission/config.json
+++ b/resource/clients/transmission/config.json
@@ -1,5 +1,6 @@
 {
   "name": "Transmission",
+  "enabled": true,
   "type": "transmission",
   "ver": "0.0.1",
   "icon": "https://raw.githubusercontent.com/transmission/transmission/master/web/images/favicon.png",

--- a/resource/clients/utorrent/config.json
+++ b/resource/clients/utorrent/config.json
@@ -1,5 +1,6 @@
 {
   "name": "µTorrent",
+  "enabled": true,
   "type": "utorrent",
   "ver": "0.0.1",
   "icon": "https://www.utorrent.com/faviconUT.ico",

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -580,8 +580,11 @@
           "removeSelectedConfirm": "Are you sure you want to delete the selected download server?",
           "ok": "OK",
           "cancel": "Cancel",
+          "yes": "Y",
+          "no": "N",
           "headers": {
             "name": "Name",
+            "enabled": "Enabled",
             "type": "Type",
             "address": "Address",
             "action": "Action"

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -552,6 +552,7 @@
           "loginPwd": "登录密码",
           "id": "ID",
           "autoStart": "发送种子时自动开始下载",
+          "enabled": "是否启用",
           "tagIMDb": "发送种子时自动添加IMDb标签（Beta）",
           "autoCreate": "<保存后自动生成>",
           "test": "测试服务器是否可连接",
@@ -575,8 +576,11 @@
           "removeSelectedConfirm": "确认要删除已选中的下载服务器吗？",
           "ok": "确认",
           "cancel": "取消",
+          "yes": "是",
+          "no": "否",
           "headers": {
             "name": "名称",
+            "enabled": "是否启用",
             "type": "类型",
             "address": "服务器地址",
             "action": "操作"

--- a/resource/schemas/Common/common.js
+++ b/resource/schemas/Common/common.js
@@ -819,6 +819,13 @@
       let menus = [];
 
       items.forEach(item => {
+        if (!item) return
+        if (!item.client) return
+        if (!item.client.name) return
+        if (item.client.enabled === false) {
+          console.log(`skip disable client: ${item.client.name}`)
+          return
+        }
         if (item.client && item.client.name) {
           menus.push({
             title:
@@ -1188,6 +1195,13 @@
           });
         });
         clients.forEach(item => {
+          if (!item) return
+          if (!item.client) return
+          if (!item.client.name) return
+          if (item.client.enabled === false) {
+            console.log(`skip disable client: ${item.client.name}`)
+            return
+          }
           if (item.client && item.client.name) {
             addMenu(item);
 
@@ -1253,7 +1267,7 @@
 	        sayThanksButton[0].click();
             success();
             setTimeout(() => {
-	          
+
               PTService.removeButton("sayThanks");
             }, 1000);
           }

--- a/resource/schemas/NexusPHP/common.js
+++ b/resource/schemas/NexusPHP/common.js
@@ -820,6 +820,13 @@
       let menus = [];
 
       items.forEach(item => {
+        if (!item) return
+        if (!item.client) return
+        if (!item.client.name) return
+        if (item.client.enabled === false) {
+          console.log(`skip disable client: ${item.client.name}`)
+          return
+        }
         if (item.client && item.client.name) {
           menus.push({
             title:
@@ -1189,6 +1196,13 @@
           });
         });
         clients.forEach(item => {
+          if (!item) return
+          if (!item.client) return
+          if (!item.client.name) return
+          if (item.client.enabled === false) {
+            console.log(`skip disable client: ${item.client.name}`)
+            return
+          }
           if (item.client && item.client.name) {
             addMenu(item);
 

--- a/resource/schemas/TNode/common.js
+++ b/resource/schemas/TNode/common.js
@@ -820,6 +820,13 @@
       let menus = [];
 
       items.forEach(item => {
+        if (!item) return
+        if (!item.client) return
+        if (!item.client.name) return
+        if (item.client.enabled === false) {
+          console.log(`skip disable client: ${item.client.name}`)
+          return
+        }
         if (item.client && item.client.name) {
           menus.push({
             title:
@@ -1189,6 +1196,13 @@
           });
         });
         clients.forEach(item => {
+          if (!item) return
+          if (!item.client) return
+          if (!item.client.name) return
+          if (item.client.enabled === false) {
+            console.log(`skip disable client: ${item.client.name}`)
+            return
+          }
           if (item.client && item.client.name) {
             addMenu(item);
 

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -727,6 +727,10 @@ export class ContextMenus {
    * 创建下载客户端上下文菜单，所有页面可用
    */
   private createClientMenus() {
+    let clients = this.options.clients.filter(c => c.enabled !== false)
+    console.log('createClientMenus', this.options.clients)
+    console.log('createClientMenus', clients)
+
     if (this.options.defaultClientId) {
       let client = this.options.clients.find((item: DownloadClient) => {
         return item.id === this.options.defaultClientId;
@@ -754,7 +758,7 @@ export class ContextMenus {
       }
     }
 
-    if (this.options.clients.length > 1) {
+    if (clients.length > 1) {
       this.add({
         id: this.rootId,
         title: this.service.i18n.t("service.contextMenus.sendTorrentToClient"), // "发送到其他服务器",
@@ -762,7 +766,7 @@ export class ContextMenus {
       });
 
       // 创建可用的客户端菜单
-      this.options.clients.forEach((client: DownloadClient) => {
+      clients.forEach((client: DownloadClient) => {
         if (client.id !== this.options.defaultClientId) {
           this.add({
             id: client.id,

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -27,6 +27,7 @@ export interface ContextMenuRules {
 
 export interface DownloadClient {
   id?: string;
+  enabled?:boolean;
   name?: string;
   // oldName?: string;
   address?: string;
@@ -627,7 +628,7 @@ export interface UserInfo {
   lastErrorMsg?: string;
   // 消息数量
   messageCount?: number;
-  // 独特分组 
+  // 独特分组
   uniqueGroups?: number;
   // “完美”FLAC
   perfectFLAC?: number;

--- a/src/options/views/settings/DownloadClients/Add.vue
+++ b/src/options/views/settings/DownloadClients/Add.vue
@@ -186,6 +186,12 @@ export default Vue.extend({
     next(step: number) {
       if (this.selectedItem && this.selectedItem.name) {
         this.selectedData = Object.assign({}, this.selectedItem);
+        // 兼容客户端模板缺少配置项的情况
+        // console.log('selectedData', this.selectedData)
+        if (this.selectedData.enabled === undefined) {
+          this.selectedData.enabled = true
+        }
+        // console.log('selectedData', this.selectedData)
         this.valid = false;
         this.step++;
       } else {

--- a/src/options/views/settings/DownloadClients/Editor.vue
+++ b/src/options/views/settings/DownloadClients/Editor.vue
@@ -35,6 +35,11 @@
           ></v-text-field>
 
           <v-switch
+              :label="$t('settings.downloadClients.editor.enabled')"
+              v-model="option.enabled"
+          ></v-switch>
+
+          <v-switch
             :label="$t('settings.downloadClients.editor.autoStart')"
             v-model="option.autoStart"
             v-if="['transmission', 'qbittorrent'].includes(option.type)"

--- a/src/options/views/settings/DownloadClients/Index.vue
+++ b/src/options/views/settings/DownloadClients/Index.vue
@@ -31,6 +31,7 @@
           <td>
             <a @click="edit(props.item)">{{ props.item.name }}</a>
           </td>
+          <td>{{ props.item.enabled === false ? $t('settings.downloadClients.index.no') : $t('settings.downloadClients.index.yes') }}</td>
           <td>{{ props.item.type }}</td>
           <td>
             <a
@@ -115,6 +116,17 @@ export default Vue.extend({
   },
   created() {
     this.items = this.$store.state.options.system.clients;
+    // console.log('clients', this.$store.state.options.clients)
+    // console.log('system clients', this.$store.state.options.system.clients)
+    // 更新旧数据
+    this.$store.state.options.clients.forEach((c: { enabled: boolean | undefined; }) => {
+      if (c.enabled === undefined) {
+        c.enabled = true
+        this.updateItem(c)
+      }
+    })
+    // console.log('clients', this.$store.state.options.clients)
+    // console.log('system clients', this.$store.state.options.system.clients)
   },
   methods: {
     add() {
@@ -186,6 +198,11 @@ export default Vue.extend({
           text: this.$t("settings.downloadClients.index.headers.name"),
           align: "left",
           value: "name"
+        },
+        {
+          text: this.$t("settings.downloadClients.index.headers.enabled"),
+          align: "left",
+          value: "enabled"
         },
         {
           text: this.$t("settings.downloadClients.index.headers.type"),


### PR DESCRIPTION
## 支持禁用部分下载客户端 #974
* 所有类型下载客户端都支持禁用

----
* 下载服务器配置
> 编辑后需要刷新  

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/9590985e-ebae-4098-8b96-215963acfdfe)
* 下载服务器编辑
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/519629f4-c525-43fc-84d4-fee331bde52c)
* 种子页
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/f8b6c53c-39f5-4f6e-8d00-ab1d5da0bb18)

* 种子详情页
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/b4b3edb1-d9cf-4ae3-a3c8-3e87fd6796f7)

## 已知问题
* 右键菜单未过滤禁用的下载客户端

> 没找到对应代码，且使用频率相对较低，先算了。欢迎告知或者直接PR  

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/1b1eff1b-f51d-4b3e-9bb6-87b51f427877)



