### PR TITLE
feat(#536): 为每个站点增加一个入口页面列表

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -182,6 +182,10 @@
       "getUserInfoAbort": "Get user profile request has been canceled. ({siteName})",
       "getUserInfoAbortError": "Cancellation failed to get user profile request. ({siteName})",
       "offline":"Offline",
+      "torrents": "Torrents",
+      "control_panel": "ControlPanel",
+      "security": "Security",
+      "2FA": "2FA",
       "headers": {
         "date": "Date",
         "site": "Site",
@@ -726,6 +730,10 @@
           "timezone": "Timezone",
           "upLoadLimit": "Upload limit",
           "upLoadLimitTip": "Upload limit (KB\/s), 0 or empty for no limit",
+          "enableQuickLink": "Enable QuickLink",
+          "enableDefaultQuickLink": "Enable Default QuickLink",
+          "quickLinkText": "Custom QuickLink Text",
+          "quickLinkTextTip": "Fill in an address in each line, and commas separate comments and URLs and colors (supports hexadecimal). Such as: 'Baidu, https://baidu.com, #2196f3'",
           "disableMessageCount": "Display message count"
         },
         "userinfo": {

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -183,6 +183,7 @@
       "getUserInfoAbortError": "Cancellation failed to get user profile request. ({siteName})",
       "offline":"Offline",
       "torrents": "Torrents",
+      "mailbox": "MailBox",
       "control_panel": "ControlPanel",
       "security": "Security",
       "2FA": "2FA",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -179,6 +179,10 @@
       "getUserInfoAbort": "{siteName} 获取用户资料请求已取消",
       "getUserInfoAbortError": "{siteName} 获取用户资料请求取消失败",
       "offline":"已离线",
+      "torrents": "种子页",
+      "control_panel": "控制面板",
+      "security": "安全设置",
+      "2FA": "2FA",
       "headers": {
         "date": "日期",
         "site": "站点",
@@ -721,6 +725,10 @@
           "timezone": "时区",
           "upLoadLimit": "上传速度限制",
           "upLoadLimitTip": "上传速度限制 (KB/s), 0或不填 不限速",
+          "enableQuickLink": "启用快捷链接",
+          "enableDefaultQuickLink": "启用默认链接",
+          "quickLinkText": "自定义快捷链接列表",
+          "quickLinkTextTip": "每行填写一个地址，逗号分隔备注和网址和颜色（支持 16进制）。如：'百度,https://baidu.com,#2196f3'",
           "disableMessageCount": "关闭消息提醒"
         },
         "userinfo": {

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -180,6 +180,7 @@
       "getUserInfoAbortError": "{siteName} 获取用户资料请求取消失败",
       "offline":"已离线",
       "torrents": "种子页",
+      "mailbox": "收件箱",
       "control_panel": "控制面板",
       "security": "安全设置",
       "2FA": "2FA",

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -271,7 +271,23 @@ export interface Site {
   disableMessageCount?: boolean;
   // 等级要求
   levelRequirements?: LevelRequirement[];
+  // 上传限速 KB/s
   upLoadLimit?: number;
+  // 启用快捷链接
+  enableQuickLink?: boolean;
+  // 启用默认快捷链接
+  enableDefaultQuickLink?: boolean;
+  userQuickLinks?: UserQuickLink[];
+}
+
+/**
+ * desc & href 都不为空才被认为是有效链接
+ * href 必须是网址
+ */
+export interface UserQuickLink {
+  desc: string;
+  href: string;
+  color?: string;
 }
 
 export interface LevelRequirement {
@@ -627,7 +643,7 @@ export interface UserInfo {
   lastErrorMsg?: string;
   // 消息数量
   messageCount?: number;
-  // 独特分组 
+  // 独特分组
   uniqueGroups?: number;
   // “完美”FLAC
   perfectFLAC?: number;

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -1109,13 +1109,56 @@ export default Vue.extend({
     },
     defaultQuickLinks: function (site: Site): UserQuickLink[] {
       let uid = site.user?.id, uname = site.user?.name
-      return [
-        {color: 'primary', desc: `${uname}(${uid})`, href: new URL(`/userdetails.php?id=${uid}`, site.activeURL).toString()},
-        {color: 'success', desc: this.$t("home.torrents").toString(), href: new URL(`/torrents.php`, site.activeURL).toString()},
-        {color: 'primary', desc: this.$t("home.control_panel").toString(), href: new URL(`/usercp.php`, site.activeURL).toString()},
-        {color: 'primary', desc: this.$t("home.security").toString(), href: new URL(`/usercp.php?action=security`, site.activeURL).toString()},
-        {color: 'primary', desc: this.$t("home.2FA").toString(), href: new URL(`/usercp.php?action=secAuth`, site.activeURL).toString()},
-      ]
+      let links: UserQuickLink[] = []
+      switch (site.schema) {
+        // from jpop
+        case 'Gazelle':
+          links = [
+            {color: 'primary', desc: `${uname}(${uid})`, href: new URL(`/user.php?id=${uid}`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.mailbox").toString(), href: new URL(`/inbox.php`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.torrents").toString(), href: new URL(`/torrents.php`, site.activeURL).toString()},
+            {color: 'primary', desc: this.$t("home.control_panel").toString(), href: new URL(`/user.php?action=edit&userid=${uid}`, site.activeURL).toString()},
+            // {color: 'primary', desc: this.$t("home.security").toString(), href: new URL(`/user.php?action=edit&userid=${uid}#paranoia_settings`, site.activeURL).toString()},
+            // {color: 'primary', desc: this.$t("home.2FA").toString(), href: new URL(`/user.php?action=edit&userid=${uid}#access_settings`, site.activeURL).toString()},
+          ]
+          break
+        // from GPW
+        case 'GazelleJSONAPI':
+          links = [
+            {color: 'primary', desc: `${uname}(${uid})`, href: new URL(`/user.php?id=${uid}`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.mailbox").toString(), href: new URL(`/inbox.php`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.torrents").toString(), href: new URL(`/torrents.php`, site.activeURL).toString()},
+            {color: 'primary', desc: this.$t("home.control_panel").toString(), href: new URL(`/user.php?action=edit&userid=${uid}`, site.activeURL).toString()},
+            {color: 'primary', desc: this.$t("home.security").toString(), href: new URL(`/user.php?action=edit&userid=${uid}#paranoia_settings`, site.activeURL).toString()},
+            // {color: 'primary', desc: this.$t("home.2FA").toString(), href: new URL(`/user.php?action=edit&userid=${uid}#access_settings`, site.activeURL).toString()},
+          ]
+          break
+        // from 观众
+        case 'NexusPHP':
+          links = [
+            {color: 'primary', desc: `${uname}(${uid})`, href: new URL(`/userdetails.php?id=${uid}`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.mailbox").toString(), href: new URL(`/messages.php`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.torrents").toString(), href: new URL(`/torrents.php`, site.activeURL).toString()},
+            {color: 'primary', desc: this.$t("home.control_panel").toString(), href: new URL(`/usercp.php`, site.activeURL).toString()},
+            {color: 'primary', desc: this.$t("home.security").toString(), href: new URL(`/usercp.php?action=security`, site.activeURL).toString()},
+            // {color: 'primary', desc: this.$t("home.2FA").toString(), href: new URL(`/usercp.php?action=secAuth`, site.activeURL).toString()},
+          ]
+          break
+        // from zhuque
+        case 'TNode':
+          links = [
+            {color: 'primary', desc: `${uname}(${uid})`, href: new URL(`/user/info`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.mailbox").toString(), href: new URL(`/message/system`, site.activeURL).toString()},
+            {color: 'success', desc: this.$t("home.torrents").toString(), href: new URL(`/torrent/list/`, site.activeURL).toString()},
+            {color: 'primary', desc: this.$t("home.control_panel").toString(), href: new URL(`/user/setting`, site.activeURL).toString()},
+          ]
+          break
+        case 'Discuz':
+        case 'UNIT3D':
+        default:
+          break
+      }
+      return links
     }
   },
 

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -95,6 +95,20 @@
               {{ props.item.user.name }}
             </template>
             <template v-else> **** </template>
+            <v-card  v-if="props.item.enableQuickLink" class="userQuickLinks">
+                <template v-if="props.item.enableDefaultQuickLink">
+                  <template v-for="link of defaultQuickLinks(props.item)">
+                    <v-btn outline elevation="2" class="x-small" target="_blank"
+                           :color="link.color" :href="link.href" >{{ link.desc }}</v-btn>
+                  </template>
+                  <hr>
+                </template>
+              <!--Vuetify 点击后新开窗口也-->
+                <template v-for="link of props.item.userQuickLinks">
+                  <v-btn outline elevation="2" class="x-small" target="_blank"
+                         :color="link.color" :href="link.href" >{{ link.desc }}</v-btn>
+                </template>
+            </v-card>
           </td>
           <td v-if="showColumn('user.levelName')">
             <v-icon v-if="showLevelRequirements" small>military_tech</v-icon>
@@ -342,7 +356,6 @@
           </td>
           <td v-if="showColumn('user.uploads')" class="number">
             <template v-if="props.item.user.uploads && props.item.user.uploads > 0">{{ props.item.user.uploads}}</template>
-            
           </td>
           <td v-if="showColumn('user.seeding')" class="number">
             <div>{{ props.item.user.seeding }}</div>
@@ -424,7 +437,7 @@ import {
   Options,
   UserInfo,
   EViewKey,
-  LevelRequirement,
+  LevelRequirement, UserQuickLink,
 } from "@/interface/common";
 import dayjs from "dayjs";
 
@@ -1094,6 +1107,16 @@ export default Vue.extend({
       }
       return "";
     },
+    defaultQuickLinks: function (site: Site): UserQuickLink[] {
+      let uid = site.user?.id, uname = site.user?.name
+      return [
+        {color: 'primary', desc: `${uname}(${uid})`, href: new URL(`/userdetails.php?id=${uid}`, site.activeURL).toString()},
+        {color: 'success', desc: this.$t("home.torrents").toString(), href: new URL(`/torrents.php`, site.activeURL).toString()},
+        {color: 'primary', desc: this.$t("home.control_panel").toString(), href: new URL(`/usercp.php`, site.activeURL).toString()},
+        {color: 'primary', desc: this.$t("home.security").toString(), href: new URL(`/usercp.php?action=security`, site.activeURL).toString()},
+        {color: 'primary', desc: this.$t("home.2FA").toString(), href: new URL(`/usercp.php?action=secAuth`, site.activeURL).toString()},
+      ]
+    }
   },
 
   filters: {
@@ -1144,6 +1167,26 @@ export default Vue.extend({
     margin: 0;
     height: 30px;
     width: 30px;
+  }
+
+  td:hover div.userQuickLinks {
+    display: block;
+  }
+
+  .userQuickLinks {
+    position: absolute;
+    display: none;
+    z-index: 999;
+    border: 1px solid;
+    max-width: 50%;
+    min-width: 405px;
+  }
+
+  .x-small {
+    height: 20px;
+    min-width: 36px;
+    padding: 0 8.8888888889px;
+    margin: 5px;
   }
 
   td:hover div.levelRequirement {

--- a/src/options/views/UserDataTimeline.vue
+++ b/src/options/views/UserDataTimeline.vue
@@ -287,6 +287,7 @@ export default Vue.extend({
           }
 
           if (user.uploads && user.uploads > 0) {
+            // https://github.com/pt-plugins/PT-Plugin-Plus/pull/1517
             if (typeof user.uploads !== 'number') {
               console.log(`${site.url}: 当前站点 uploads 类型为 ${typeof user.uploads}，强制转换为 number 类型`)
               user.uploads = parseInt(user.uploads) || 0;

--- a/src/options/views/settings/Sites/Editor.vue
+++ b/src/options/views/settings/Sites/Editor.vue
@@ -136,6 +136,7 @@
           </template>
         </v-autocomplete>
 
+        <!--上传限速-->
         <v-text-field
                 v-model="site.upLoadLimit"
                 :label="$t('settings.sites.editor.upLoadLimit')"
@@ -178,6 +179,17 @@
 
         <!-- 消息提醒开关 -->
         <v-switch :label="$t('settings.sites.editor.disableMessageCount')" v-model="site.disableMessageCount"></v-switch>
+        <!--启用快捷链接-->
+        <v-switch :label="$t('settings.sites.editor.enableQuickLink')" v-model="site.enableQuickLink"/>
+        <!--启用默认链接-->
+        <v-switch :label="$t('settings.sites.editor.enableDefaultQuickLink')" :disabled="!site.enableQuickLink"
+                  v-model="site.enableDefaultQuickLink"/>
+        <!--自定义快捷链接列表-->
+        <v-textarea
+            v-model="quickLinkText" :disabled="!site.enableQuickLink"
+            :label="$t('settings.sites.editor.quickLinkText')"
+            :hint="$t('settings.sites.editor.quickLinkTextTip')"
+        ></v-textarea>
       </v-form>
     </v-card-text>
   </v-card>
@@ -200,6 +212,7 @@ export default Vue.extend({
         }
       },
       cdn: "",
+      quickLinkText: "",
       valid: false,
       site: {} as Site,
       timezone: [
@@ -343,6 +356,11 @@ export default Vue.extend({
         } else {
           this.cdn = "";
         }
+        if (this.site.userQuickLinks) {
+          this.quickLinkText = this.site.userQuickLinks.map(u => `${u.desc},${u.href},${u.color ? u.color : ''}`).join('\n')
+        } else {
+          this.quickLinkText = ""
+        }
         this.$emit("change", {
           data: this.site,
           valid: this.valid
@@ -370,6 +388,19 @@ export default Vue.extend({
       }
 
       this.site.cdn = result;
+    },
+    quickLinkText() {
+      this.site.userQuickLinks = this.quickLinkText.split(/\n/).filter(_ => !!_)
+          .map(_ => _.split(/\s*[,，]\s*/)).filter(([desc, href, color]) => {
+            let b1 = !!desc && !!href
+            let b2 = true
+            try {
+              new URL(href)
+            } catch (e) {
+              b2 = false
+            }
+            return b1 && b2
+          }).map(([desc, href, color]) => ({desc, href, color}))
     },
     initData() {
       if (this.initData) {


### PR DESCRIPTION
## feat(#536): 为每个站点增加一个入口页面列表，当收藏用

## 关联 issue
[#536](https://github.com/pt-plugins/PT-Plugin-Plus/issues/536#issuecomment-647529898) #527 

## 部分使用场景
> 根据群友反馈，去掉了 2FA， 增加了 收件箱 的入口。  
> 收件箱入口 可以配合 PTPP 默认的消息提醒使用。~~每次打开小红点页面也挺麻烦的不是？~~   


* 直达控制面板，调整个人设置，复制 passkey
* 直达用户详情
* 管理可以只定义如申诉页，种审页，论坛特定板块

> 这个和用户等级一样。 鼠标 hover 才会显示出来。默认不显示，可以在站点设置中调整。  

## Priview
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/cb3faa51-da6f-4ad4-a860-fe18d8be8b0c)
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/a752468b-0f2c-4cef-8672-8a8b72afb666)

## 类似脚本

* [pter 快捷链接](https://github.com/IITII/nexusphp_forums#pter-%E5%BF%AB%E6%8D%B7%E9%93%BE%E6%8E%A5)
* [greasyfork](https://greasyfork.org/zh-CN/scripts/467909-pter-%E5%BF%AB%E6%8D%B7%E9%93%BE%E6%8E%A5)