### PR TITLE
fix(#1260): 对齐数据更新时间

### DIFF
--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -103,7 +103,7 @@
                   </template>
                   <hr>
                 </template>
-              <!--Vuetify 点击后新开窗口也-->
+                <!--点击后在新标签页打开-->
                 <template v-for="link of props.item.userQuickLinks">
                   <v-btn outline elevation="2" class="x-small" target="_blank"
                          :color="link.color" :href="link.href" >{{ link.desc }}</v-btn>
@@ -398,10 +398,10 @@
             {{ props.item.user.joinTime | timeAgo(showWeek) }}
           </td>
           <td v-if="showColumn('user.lastUpdateTime')" class="number">
-            <v-btn depressed small :to="`statistic/${props.item.host}`" :title="$t('home.statistic')">{{
-                props.item.user.lastUpdateTime |
-                formatDate("YYYY-MM-DD HH:mm:ss")
-            }}</v-btn>
+            <v-btn depressed small class="lastUpdateTime"
+                   :to="`statistic/${props.item.host}`" :title="$t('home.statistic')">
+              {{ props.item.user.lastUpdateTime | formatDate("YYYY-MM-DD HH:mm:ss") }}
+            </v-btn>
           </td>
           <td v-if="showColumn('user.lastUpdateStatus')" class="center">
             <v-progress-circular indeterminate :width="3" size="30" color="green" v-if="props.item.user.isLoading">
@@ -1245,6 +1245,10 @@ export default Vue.extend({
 
   .select {
     max-width: 180px;
+  }
+
+  .lastUpdateTime {
+    margin-right: 0;
   }
 }
 </style>


### PR DESCRIPTION
#1260 
* 至于字段目前的对齐方式，我觉得挺不错的。数值之类的右对齐没问题，先不说设计，数值有长有短。居中肯定不行，左对齐也不行，只能右对齐。 ~~不信可以自己改改试试，改 align 值即可~~

https://github.com/pt-plugins/PT-Plugin-Plus/blob/91a2575b839cd64f3336552838314bcbdd1107fb/src/options/views/Home.vue#L309-L372

* 更新前
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/3d793a3e-1579-494e-9f53-502e7fd665d1)

* 更新后
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/08817a8c-d563-4991-92bc-e2e69600f9a5)

