### PR TITLE
feat: deluge 限速支持

### DIFF
--- a/resource/clients/deluge/init.js
+++ b/resource/clients/deluge/init.js
@@ -49,7 +49,7 @@
           case "addTorrentFromURL":
             this.addTorrentFromUrl(data, result => {
               resolve(result);
-            });
+            }, data.upLoadLimit);
             break;
 
           // 测试是否可连接
@@ -171,19 +171,20 @@
      * @param {*} data
      * @param {*} callback
      */
-    addTorrentFromUrl(data, callback) {
+    addTorrentFromUrl(data, callback, uploadLimit = 0) {
       let url = data.url;
+      // https://github.com/deluge-torrent/deluge/blob/a459e78268ae8002a9cfc8caf6d410fa45b1d805/deluge/ui/console/utils/config.py#L89
+      let options = {
+        download_location: data.savePath,
+        // deluge max_upload_speed 的定义也是 int
+        max_upload_speed: uploadLimit && uploadLimit > 0 ? parseInt(uploadLimit) : undefined,
+      }
 
       // 磁性连接（代码来自原版WEBUI）
       if (url.startsWith('magnet:')) {
         this.addTorrent({
             method: "core.add_torrent_url",
-            params: [
-              url,
-              {
-                download_location: data.savePath
-              }
-            ]
+            params: [ url, options ]
           },
           callback
         );
@@ -208,13 +209,7 @@
 
             this.addTorrent({
               method: "core.add_torrent_file",
-              params: [
-                "",
-                metainfo,
-                {
-                  download_location: data.savePath
-                }
-              ]
+              params: [ "", metainfo, options ]
             },
               callback
             );

--- a/src/options/views/settings/Sites/Editor.vue
+++ b/src/options/views/settings/Sites/Editor.vue
@@ -138,7 +138,7 @@
 
         <!--上传限速-->
         <v-text-field
-                v-model="site.upLoadLimit"
+                v-model="site.upLoadLimit" type="number"
                 :label="$t('settings.sites.editor.upLoadLimit')"
                 :placeholder="$t('settings.sites.editor.upLoadLimitTip')"
         ></v-text-field>


### PR DESCRIPTION
#145

## 其他客户端
* [废弃] 从 linuxserver.io 的 docker 镜像来看，rtorrent 和 flood 已经很久没更新了。主观感觉上使用的人也很少，不再单独适配。
* [搁置] utorrent 只能再种子添加后限速，且添加成功时不会返回种子 hash（类似于种子 id，调用限速接口需要。

```
请求网址: http://xxx:8082/gui/?token=xxx&action=setprops&s=ulrate&v=10240&hash=E64BE295746E79657138B71926342B43BB01C9C0
请求方法: GET
```
## 限速结果图

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/cf07d90f-ddcf-4c3d-84ba-37a2cb5ca99b)
