### PR TITLE
fix: 调整用户级别显示

### DIFF
--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -699,23 +699,27 @@ export default Vue.extend({
      * 等级名称有中英文之分，没法直接区分
      */
     getUserLevelGroup(site: Site) {
-      let userLevel = site.user?.levelName
-      if (userLevel?.toLowerCase().includes('vip')) {
-        return 'vip'
-      } else {
-        return 'user'
+      let userLevel = site.user?.levelName?.toLowerCase()
+      let specialNames = {
+        manager: 'admin,moderator,sys,retire,管理,版主,发种,保种,上传,退休'.split(/[,，]/ig),
+        vip: 'vip,贵宾'.split(/[,，]/ig),
       }
-      // let levels = site.levelRequirements?.map(_ => _.name)
-      // if (levels?.some(_ => _ === userLevel)) {
-      //   return 'manager'
-      // } else if (userLevel?.toLowerCase().includes('vip')) {
-      //   return 'vip'
-      // } else {
-      //   return 'user'
-      // }
+      specialNames.manager = specialNames.manager.filter(_ => !!_)
+      specialNames.vip = specialNames.vip.filter(_ => !!_)
+      let res = 'user'
+      for (let k in specialNames) {
+        // @ts-ignore
+        let levelNames = specialNames[k]
+        if (levelNames.some((n: string) => userLevel?.includes(n))) {
+          res = k
+          break
+        }
+      }
+      return res
     },
     getDoneIcon(site: Site) {
-      const icons = {manager: 'verified', vip: 'download_done', user: 'done'}
+      const icons = {manager: 'manage_accounts', vip: 'verified', user: 'done'}
+      // @ts-ignore
       return icons[this.getUserLevelGroup(site)] || icons.user
     },
     isUserGroup(site: Site) {

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -115,7 +115,7 @@
             {{ showUserLevel ? props.item.user.levelName : "****" }}
             <template v-if="showLevelRequirements">
               <template v-if="props.item.levelRequirements">
-                <template v-if="props.item.user.nextLevels && props.item.user.nextLevels.length > 0">
+                <template v-if="isUserGroup(props.item) && props.item.user.nextLevels && props.item.user.nextLevels.length > 0">
                   <template v-for="nextLevel in props.item.user.nextLevels">
                     <div>
                       <v-icon small>keyboard_tab</v-icon>
@@ -192,7 +192,7 @@
                   </template>
                 </template>
                 <template v-else-if="props.item.user.name">
-                  <v-icon small color="green darken-4">done</v-icon>
+                  <v-icon small color="green darken-4">{{ getDoneIcon(props.item) }}</v-icon>
                 </template>
                 <v-card class="levelRequirement">
                   <template v-for="levelRequirement of props.item.levelRequirements">
@@ -696,6 +696,32 @@ export default Vue.extend({
       }
     },
     /**
+     * 等级名称有中英文之分，没法直接区分
+     */
+    getUserLevelGroup(site: Site) {
+      let userLevel = site.user?.levelName
+      if (userLevel?.toLowerCase().includes('vip')) {
+        return 'vip'
+      } else {
+        return 'user'
+      }
+      // let levels = site.levelRequirements?.map(_ => _.name)
+      // if (levels?.some(_ => _ === userLevel)) {
+      //   return 'manager'
+      // } else if (userLevel?.toLowerCase().includes('vip')) {
+      //   return 'vip'
+      // } else {
+      //   return 'user'
+      // }
+    },
+    getDoneIcon(site: Site) {
+      const icons = {manager: 'verified', vip: 'download_done', user: 'done'}
+      return icons[this.getUserLevelGroup(site)] || icons.user
+    },
+    isUserGroup(site: Site) {
+      return this.getUserLevelGroup(site) === 'user'
+    },
+    /**
      * 格式化一些用户信息
      */
     formatUserInfo(user: UserInfoEx, site: Site) {
@@ -740,19 +766,15 @@ export default Vue.extend({
             if (Number(levelRequirement.level) < userLevel)
               continue;
 
-            if (levelRequirement.alternative)
-            {
-              for (var option of levelRequirement.alternative)
-              {
+            if (levelRequirement.alternative) {
+              for (var option of levelRequirement.alternative) {
                 var newLevelRequirement = Object.assign({}, levelRequirement)
-                for(var key of Object.keys(option) as Array<keyof LevelRequirement>) {
-                  {
-
+                for(var key of Object.keys(option) as Array<keyof LevelRequirement>) {{
                     if (option[key])
                       newLevelRequirement[key] = option[key] as any
                   }
                 }
-                //console.log(newLevelRequirement)
+                // console.log(newLevelRequirement)
                 var nextLevel = this.calculateNextLeve(user, newLevelRequirement);
                 if (nextLevel) {
                   //console.log(nextLevel)
@@ -766,9 +788,7 @@ export default Vue.extend({
 
               if (user.nextLevels.length)
                   break;
-            }
-            else
-            {
+            } else {
               let nextLevel = this.calculateNextLeve(user, levelRequirement);
               if (nextLevel) {
                 if (user.nextLevels.length) {


### PR DESCRIPTION
#1506
* VIP 不显示升级条件，hover还是可以正常看到目前符合哪一个等级的要求
* 对不同的用户组（VIP，管理，普通用户）显示不同的 done 按钮
* 按通用名称进行了简单的用户分组
  * 管理：admin,moderator,sys,retire,管理,版主,发种,保种,上传,退休
  * VIP：vip,贵宾

* 预设 icon 从左到右：普通用户，管理，VIP
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/225cd2e5-7194-4d78-b8ae-d7ad74e4c9bd)
