### PR TITLE
fix: 海棠双份按钮

### DIFF
--- a/resource/sites/htpt.cc/config.json
+++ b/resource/sites/htpt.cc/config.json
@@ -98,22 +98,11 @@
     {
       "name": "种子列表",
       "pages": [
-        "/torrents.php",
         "/live.php"
       ],
       "scripts": [
         "/schemas/NexusPHP/common.js",
         "/schemas/NexusPHP/torrents.js"
-      ]
-    },
-    {
-      "name": "种子详情页面",
-      "pages": [
-        "/details.php"
-      ],
-      "scripts": [
-        "/schemas/NexusPHP/common.js",
-        "/schemas/NexusPHP/details.js"
       ]
     }
   ]


### PR DESCRIPTION
* 去掉重复的 plugin

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/daaf8c1c-0580-40c7-a442-6f5898dea52c)
