### PR TITLE
fix: 调整搜索方案默认搜索逻辑, 可在 通用配置-搜索 中调整

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -1,6 +1,6 @@
 ## PTPP 开发指引
 
-* https://github.com/pt-plugins/PT-Plugin-Plus/wiki/develop
+* https://github.com/pt-plugins/PT-Plugin-Plus/wiki/developer
 
 ## PTPP 后端日志查看
 
@@ -11,7 +11,9 @@
 
 ![img](./docs/images/1.png)
 
-5. 从项目结构上说 `src/background` 的日志将会输出到 背景页。`src/options` 里面的日志，将会输出到 `index.html`。打开F12即可看见。
+5. 从项目结构上来说, 打开F12即可看见日志。
+   1. `src/background` 的日志将会输出到 `背景页`。
+   2. `src/options` 里面的日志，将会输出到 `index.html`。
 
 ```
 .

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -498,6 +498,7 @@
         "saveSearchKey": "Save historical search keyword records",
         "showMoiveInfoCardOnSearch": "Show movie and rating information when searching by IMDb number",
         "getMovieInformationBeforeSearching": "When entering a search keyword, load relevant information from Douban for pre-selection",
+        "autoSearchWhenSwitchSolution": "When changing search solution, re-search immediately",
         "maxMovieInformationCount": "Maximum display number of entries (1-20):",
         "searchModeForItem": "When clicking on a pre-selected item:",
         "showToolbarOnContentPage": "Enable site page plugin icons and toolbars (such as one-click downloads, etc.)",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -493,6 +493,7 @@
         "saveSearchKey": "保存搜索关键字",
         "showMoiveInfoCardOnSearch": "当以 IMDb 编号搜索时显示电影及评分信息",
         "getMovieInformationBeforeSearching": "当输入搜索关键字时，从豆瓣加载相关信息以供预选",
+        "autoSearchWhenSwitchSolution": "当搜索方案切换时，立即触发搜索",
         "maxMovieInformationCount": "最多显示条目（1-20）：",
         "searchModeForItem": "当点击预选条目时：",
         "showToolbarOnContentPage": "启用站点页面助手图标和工具栏（如一键下载等）",

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -135,6 +135,8 @@ export interface Options {
   showMoiveInfoCardOnSearch?: boolean;
   // 在搜索之前一些选项配置
   beforeSearchingOptions?: BeforeSearching;
+  // 搜索方案切换的时候是否自动搜索
+  autoSearchWhenSwitchSolution?: boolean;
   // 在页面中显示工具栏
   showToolbarOnContentPage?: boolean;
   // 当前语言

--- a/src/options/components/SearchBox.vue
+++ b/src/options/components/SearchBox.vue
@@ -398,7 +398,13 @@ export default Vue.extend({
 
     searchTorrent(key?: string) {
       key = key || this.searchKey;
+      console.log(`searchTorrent: key: ${key}, searchKey: ${this.searchKey}`)
       if (!key) {
+        return;
+      }
+      const targetRoute = {name: "search-torrent", params: {key,},}
+      if (key === this.searchKey && this.$router.currentRoute.name === targetRoute.name) {
+        console.log(`skip same searchTorrent: key: ${key}, searchKey: ${this.searchKey}`)
         return;
       }
 
@@ -409,12 +415,7 @@ export default Vue.extend({
         lastSearchKey: this.searchKey,
       });
 
-      this.$router.push({
-        name: "search-torrent",
-        params: {
-          key: key,
-        },
-      });
+      this.$router.push(targetRoute);
     },
     changeSearchSolution(solution?: SearchSolution) {
       let defaultSearchSolutionId = "";

--- a/src/options/views/search/SearchTorrent.ts
+++ b/src/options/views/search/SearchTorrent.ts
@@ -206,11 +206,13 @@ export default Vue.extend({
   watch: {
     key(newValue, oldValue) {
       if (newValue && newValue != oldValue) {
+        console.log('watch search key', newValue, oldValue)
         this.doSearch();
       }
     },
     host(newValue, oldValue) {
       if (newValue && newValue != oldValue) {
+        console.log('watch search host', newValue, oldValue)
         this.doSearch();
       }
     },
@@ -221,9 +223,14 @@ export default Vue.extend({
       this.haveError = this.errorMsg != "";
     },
     "$store.state.options.defaultSearchSolutionId"(newValue, oldValue) {
+      console.log('watch search defaultSearchSolutionId', newValue, oldValue)
       // 设置为<默认>时，newValue 为空，故与 key, host 处理方式不同
       if (newValue != oldValue) {
-        this.doSearch();
+        if (this.$store.state.options.autoSearchWhenSwitchSolution) {
+          this.doSearch();
+        } else {
+          console.log(`切换搜索方案 - 跳过搜索, 可在 常规设置 - 搜索 中开启自动搜索`)
+        }
       }
     },
     loading() {

--- a/src/options/views/settings/Base/Index.vue
+++ b/src/options/views/settings/Base/Index.vue
@@ -282,6 +282,13 @@
                       :label="$t('settings.base.showMoiveInfoCardOnSearch')"
                     ></v-switch>
 
+                    <!-- 搜索方案切换的时候是否自动搜索 -->
+                    <v-switch
+                        color="success"
+                        v-model="options.autoSearchWhenSwitchSolution"
+                        :label="$t('settings.base.autoSearchWhenSwitchSolution')"
+                    ></v-switch>
+
                     <!-- 在搜索之前一些选项配置 -->
                     <v-switch
                       color="success"
@@ -789,7 +796,7 @@ export default Vue.extend({
       ).toString();
     }
   },
-  watch: { 
+  watch: {
     successMsg: {
       handler() {
         this.haveSuccess = this.successMsg != "";


### PR DESCRIPTION
## fix: 调整搜索方案默认搜索逻辑, 可在 通用配置-搜索 中调整

https://github.com/pt-plugins/PT-Plugin-Plus/issues/257
https://github.com/pt-plugins/PT-Plugin-Plus/pull/1508

## 截图

<img width="773" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/483ae6ba-d1f3-47f9-a2ee-46ac2fa6b7c3">
<img width="960" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/eaa9dbac-345f-4ff6-b5cf-0baed0ba5f0a">

