### PR TITLE
feat:搜索结果页面可选择标题中间省略

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -329,6 +329,7 @@
       "searching": "Searching, please wait...",
       "cancelSearch": "Cancel search",
       "showCheckbox": "Multiple selection",
+      "titleMiddleEllipsis": "Title Middle Ellipsis",
       "noTag": "No tag",
       "allSites": "All Sites",
       "multiDownloadConfirm": "The number of torrents currently downloaded exceeds one, and the browser may prompt multiple times to save. Do you want to continue?",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -324,6 +324,7 @@
       "searching": "正在搜索中，请稍候……",
       "cancelSearch": "取消搜索",
       "showCheckbox": "多选",
+      "titleMiddleEllipsis": "标题中间省略",
       "noTag": "无标签",
       "allSites": "全部站点",
       "multiDownloadConfirm": "当前下载的种子数量超过一个，浏览器可能会多次提示保存，是否继续？",

--- a/src/options/views/search/SearchTorrent.scss
+++ b/src/options/views/search/SearchTorrent.scss
@@ -14,7 +14,9 @@
     table.v-table tbody tr:nth-child(even) {
       background-color: #f1f1f1;
     }
-
+    table.v-table tbody tr:nth-child(odd) {
+      background-color: #fff
+    }
     table.v-table tbody tr[active='true'] {
       background-color: #B3E5FC !important;
     }
@@ -22,13 +24,60 @@
     table.v-table.theme--dark tbody tr:nth-child(even) {
       background-color: #1f1f1f;
     }
+    table.v-table.theme--dark tbody tr:nth-child(odd) {
+      background-color: #424242;
+    }
 
     table.v-table.theme--dark tbody tr[active='true'] {
       background-color: #4c1a03 !important;
     }
+
+    table.v-table tbody tr:hover {
+      background-color: #f1f1f1
+    }
+
+    table.v-table.theme--dark tbody tr:hover {
+      background-color: #616161
+    }
   }
 
+  .titleWrap{
+    position: relative;
+    line-height: 2;
+    background: inherit;
+    height: 2.5em;
+    overflow: hidden
+  }
+  .titleFull {
+    display: block;
+    max-height: 4em;
+    white-space: normal;
+}
+  .titleEllipsisMiddle{
+    display: block;
+    position: relative;
+    text-align: justify;
+    background: inherit;
+    height: 2em;
+    overflow: hidden;
+    top: -4em;
+  }
+
+  .titleEllipsisMiddle:before{
+    content: attr(title);
+    width: 50%;
+    position: relative;
+    background: inherit;
+    float: right;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    direction: rtl;
+  }
+
+
   .titleCell {
+    background: inherit;
     max-width: 35vw;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/options/views/search/SearchTorrent.ts
+++ b/src/options/views/search/SearchTorrent.ts
@@ -112,6 +112,7 @@ export default Vue.extend({
         progress: 0
       },
       showCategory: false,
+      titleMiddleEllipsis: false,
       fixedTable: false,
       siteContentMenus: {} as any,
       clientContentMenus: [] as any,
@@ -153,7 +154,8 @@ export default Vue.extend({
 
     let viewOptions = this.$store.getters.viewsOptions(EViewKey.searchTorrent, {
       checkBox: false,
-      showCategory: false
+      showCategory: false,
+      titleMiddleEllipsis: false
     });
     Object.assign(this, viewOptions);
 
@@ -1940,7 +1942,8 @@ export default Vue.extend({
         key: EViewKey.searchTorrent,
         options: {
           checkBox: this.checkBox,
-          showCategory: this.showCategory
+          showCategory: this.showCategory,
+          titleMiddleEllipsis:this.titleMiddleEllipsis
         }
       });
     },

--- a/src/options/views/search/SearchTorrent.vue
+++ b/src/options/views/search/SearchTorrent.vue
@@ -500,6 +500,13 @@
                     :label="$t('searchTorrent.showCategory')"
                     @change="updateViewOptions"
                   ></v-switch>
+                  <!-- 标题中间省略 -->
+                  <v-switch
+                    color="success"
+                    v-model="titleMiddleEllipsis"
+                    :label="$t('searchTorrent.titleMiddleEllipsis')"
+                    @change="updateViewOptions"
+                  ></v-switch>
                 </v-container>
               </v-card>
             </v-menu>
@@ -587,7 +594,36 @@
             >
               <img :src="props.item.site.icon" />
             </v-avatar>
+            <!--标题中间省略-->
+            <div
+             v-if="titleMiddleEllipsis && !$vuetify.breakpoint.xs"
+             class="titleWrap">
             <a
+              :href="props.item.link"
+              target="_blank"
+              v-html="props.item.titleHTML"
+              :title="props.item.title"
+              rel="noopener noreferrer nofollow"
+              :class="[
+                $vuetify.breakpoint.xs ? 'body-2' : 'subheading titleFull',
+                'font-weight-medium',
+              ]"
+            ></a>
+            <a
+              :href="props.item.link"
+              target="_blank"
+              v-html="props.item.titleHTML"
+              :title="'·title:'+props.item.title"
+              rel="noopener noreferrer nofollow"
+              :class="[
+                $vuetify.breakpoint.xs ? 'body-2' : 'subheading titleEllipsisMiddle',
+                'font-weight-medium',
+              ]"
+            ></a>
+            </div>
+
+             <a
+              v-else
               :href="props.item.link"
               target="_blank"
               v-html="props.item.titleHTML"


### PR DESCRIPTION
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31879581/82dee168-7031-4b7b-911d-b569d009d354)

开启后种子标题会从中间省略

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31879581/b271490a-0fa0-4822-be9a-2e1f8ca8dd93)
