### PR TITLE
fix:时间轴错误图片处理优化

### DIFF
--- a/src/options/views/UserDataTimeline.vue
+++ b/src/options/views/UserDataTimeline.vue
@@ -555,6 +555,9 @@ export default Vue.extend({
             FileSaver.saveAs(blob, "PT-Plugin-Plus-UserData.png");
           }
           this.shareing = false;
+        }).catch(error => {
+          console.log('error:', error);
+          this.shareing = false;
         });
       }, 500);
     },

--- a/src/options/views/UserDataTimeline.vue
+++ b/src/options/views/UserDataTimeline.vue
@@ -309,7 +309,6 @@ export default Vue.extend({
     this.init();
   },
   mounted() {
-    this.replaceImageToBase64();
   },
   methods: {
     init() {
@@ -516,9 +515,6 @@ export default Vue.extend({
       });
 
       this.infos.total.ratio = this.getRatio(this.infos.total);
-      setTimeout(() => {
-        this.replaceImageToBase64();
-      }, 200);
     },
     getRatio(info: any): number {
       let downloaded = info.downloaded as number;
@@ -546,6 +542,7 @@ export default Vue.extend({
       setTimeout(() => {
         let div = this.$refs.userDataCard as HTMLDivElement;
         domtoimage.toBlob(div, {
+          imagePlaceholder: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
           filter: (node) => {
             if (node.nodeType === 1) {
               return !(node as Element).classList.contains('by_pass_canvas')


### PR DESCRIPTION
通过分析[dom-to-image](https://github.com/tsayen/dom-to-image)库源码，发现对[失败图片](https://github.com/tsayen/dom-to-image/blob/master/src/dom-to-image.js#L496)的处理逻辑中有个`imagePlaceholder`属性至关重要，如果没有设置将会**直接报错**，所以只需要设置一个默认图片就可以完美解决**如果图片获取失败就一直转圈的问题**