### PR TITLE
feat: add comments and date in search mobile view

### DIFF
--- a/src/options/views/search/SearchTorrent.vue
+++ b/src/options/views/search/SearchTorrent.vue
@@ -663,8 +663,13 @@
               <v-flex xs3 class="pt-2 captionText">
                 <v-icon style="font-size:12px;margin-bottom: 2px;">arrow_upward</v-icon>
                 {{ props.item.seeders }}
-                <v-icon style="font-size:12px;margin-bottom: 2px;">arrow_downward</v-icon>
-                {{ props.item.leechers }}
+                <v-icon style="font-size:12px;margin-bottom: 2px;">comment</v-icon>
+                {{ props.item.comments }}
+              </v-flex>
+              <v-flex xs3 class="pt-2 captionText">
+                {{
+                props.item.time | formatDate('YYYY-MM-DD')
+                }}
               </v-flex>
               <v-flex xs3>
                 <!-- 进度条 -->


### PR DESCRIPTION
Old:
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/4102853/71351836-53bd-45e3-a157-105831d96f9c)
New:
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/4102853/54dcabd2-16ca-45f3-9179-f5eff625e82c)
在种子搜索结果的移动端视图，增加评论数和发布日期信息，这个相比即时上传人数的信息更有价值。
望采纳。