### PR TITLE
feat: 支持站点分组

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -161,6 +161,7 @@
     "home": {
       "title": "My Data",
       "getInfos": "Refresh my data",
+      "getGroupInfos": "Refresh group data",
       "cancelRequest": "Cancel request",
       "requesting": "Requesting",
       "siteName": "Site name",
@@ -171,11 +172,12 @@
       "showHnR": "H&R",
       "showLastUpdateTimeAsRelativeTime":"Last update time as relative time",
       "selectColumns": "Select Columns",
+      "selectedTags": "Selected Tags",
       "week": "Expressed in weeks",
       "timeline": "Time line",
       "settings": "Settings",
       "statistic": "Statistic",
-      "openAllSites": "Open all sites",
+      "openAllSites": "Open group sites",
       "openAllUnReadMsg": "Open a site with unread messages",
       "openAllStatusErr": "Open a site with abnormal status",
       "newMessage": "New message",
@@ -191,6 +193,12 @@
       "control_panel": "ControlPanel",
       "security": "Security",
       "2FA": "2FA",
+      "tags": {
+        "__all__": "ALL",
+        "__unTagged__": "UnTagged",
+        "__unReadMsg__": "UnReadMsg",
+        "__statusError__": "StatusError"
+      },
       "headers": {
         "date": "Date",
         "site": "Site",
@@ -731,6 +739,8 @@
         "editor": {
           "defaultClient": "Download server (if not selected, the default download server of the basic settings will prevail)",
           "name": "Site name",
+          "siteGroup": "Site Group",
+          "siteGroupTip": "Press Enter to add multiple group.",
           "tags": "Tags",
           "inputTags": "press Enter to add multiple",
           "schema": "Site schema",

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -505,7 +505,7 @@
         "autoBackupDataTip4": "Backup to",
         "searchResultOrderBySitePriority": "When the search results are clicked on the site header, they are sorted by site priority (effective after refreshing the page after saving)",
         "saveSearchKey": "Save historical search keyword records",
-        "showMoiveInfoCardOnSearch": "Show movie and rating information when searching by IMDb number",
+        "showMovieInfoCardOnSearch": "Show movie and rating information when searching by IMDb number",
         "getMovieInformationBeforeSearching": "When entering a search keyword, load relevant information from Douban for pre-selection",
         "autoSearchWhenSwitchSolution": "When changing search solution, re-search immediately",
         "maxMovieInformationCount": "Maximum display number of entries (1-20):",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -500,7 +500,7 @@
         "autoBackupDataTip4": "上传数据到",
         "searchResultOrderBySitePriority": "搜索结果点击站点表头时，按站点优先级别排序（保存后需刷新页面后生效）",
         "saveSearchKey": "保存搜索关键字",
-        "showMoiveInfoCardOnSearch": "当以 IMDb 编号搜索时显示电影及评分信息",
+        "showMovieInfoCardOnSearch": "当以 IMDb 编号搜索时显示电影及评分信息",
         "getMovieInformationBeforeSearching": "当输入搜索关键字时，从豆瓣加载相关信息以供预选",
         "autoSearchWhenSwitchSolution": "当搜索方案切换时，立即触发搜索",
         "maxMovieInformationCount": "最多显示条目（1-20）：",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -158,6 +158,7 @@
     "home": {
       "title": "我的数据",
       "getInfos": "刷新我的数据",
+      "getGroupInfos": "刷新分组数据",
       "cancelRequest": "取消请求",
       "requesting": "正在请求",
       "siteName": "网站名称",
@@ -168,11 +169,12 @@
       "showHnR": "H&R",
       "showLastUpdateTimeAsRelativeTime": "最后更新时间显示为相对时间",
       "selectColumns": "过滤列",
+      "selectedTags": "标签分组过滤",
       "week": "时间显示为周数",
       "timeline": "时间轴",
       "settings": "参数",
       "statistic": "数据图表",
-      "openAllSites": "打开所有站点",
+      "openAllSites": "打开分组站点",
       "openAllUnReadMsg": "打开有未读消息的站点",
       "openAllStatusErr": "打开状态异常的站点",
       "newMessage": "新消息",
@@ -188,6 +190,12 @@
       "control_panel": "控制面板",
       "security": "安全设置",
       "2FA": "2FA",
+      "tags": {
+        "__all__": "全部",
+        "__unTagged__": "未加标签",
+        "__unReadMsg__": "未读消息",
+        "__statusError__": "状态异常"
+      },
       "headers": {
         "date": "日期",
         "site": "站点",
@@ -727,6 +735,8 @@
         "editor": {
           "defaultClient": "指定下载服务器（如不选择则以基本设置的默认下载服务器为准）",
           "name": "站点名称",
+          "siteGroup": "站点分组",
+          "siteGroupTip": "分组输入完成后按回车添加，可添加多个",
           "tags": "站点标签",
           "inputTags": "标签输入完成后按回车添加，可添加多个",
           "schema": "网站架构",

--- a/src/background/config.ts
+++ b/src/background/config.ts
@@ -89,7 +89,7 @@ class Config {
     ],
     searchSolutions: [],
     navBarIsOpen: true,
-    showMoiveInfoCardOnSearch: true,
+    showMovieInfoCardOnSearch: true,
     beforeSearchingOptions: {
       getMovieInformation: true,
       maxMovieInformationCount: 5,

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -304,6 +304,8 @@ export interface Site {
   // 启用默认快捷链接
   enableDefaultQuickLink?: boolean;
   userQuickLinks?: UserQuickLink[];
+  // 使用站点标签进行分组
+  // siteGroups?: string[];
 }
 
 /**

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -155,7 +155,7 @@ export interface Options {
   // 导航栏是否已打开
   navBarIsOpen?: boolean;
   // 在搜索时显示电影信息（搜索IMDb时有效）
-  showMoiveInfoCardOnSearch?: boolean;
+  showMovieInfoCardOnSearch?: boolean;
   // 在搜索之前一些选项配置
   beforeSearchingOptions?: BeforeSearching;
   // 搜索方案切换的时候是否自动搜索

--- a/src/interface/enum.ts
+++ b/src/interface/enum.ts
@@ -446,3 +446,17 @@ export enum ERestoreError {
   needSecretKey = "needSecretKey",
   errorSecretKey = "errorSecretKey"
 }
+
+export enum ETagType {
+  all = "__all__",
+  unTagged = "__unTagged__",
+  unReadMsg = "__unReadMsg__",
+  statusError = "__statusError__",
+}
+
+export enum EOpenType {
+  openAllSites = "openAllSites",
+  openAllUnReadMsg = "openAllUnReadMsg",
+  openAllStatusErr = "openAllStatusErr",
+}
+

--- a/src/options/views/search/SearchTorrent.vue
+++ b/src/options/views/search/SearchTorrent.vue
@@ -3,7 +3,7 @@
     <MovieInfoCard
       :IMDbId="IMDbId"
       :doubanId="searchPayload.doubanId"
-      v-if="!!options.showMoiveInfoCardOnSearch"
+      v-if="!!options.showMovieInfoCardOnSearch"
     />
     <v-alert :value="true" type="info" style="padding:8px 16px;">
       {{ $t("searchTorrent.title") }} [{{ key }}], {{ searchMsg }}

--- a/src/options/views/settings/Base/Index.vue
+++ b/src/options/views/settings/Base/Index.vue
@@ -294,8 +294,8 @@
 
                     <v-switch
                       color="success"
-                      v-model="options.showMoiveInfoCardOnSearch"
-                      :label="$t('settings.base.showMoiveInfoCardOnSearch')"
+                      v-model="options.showMovieInfoCardOnSearch"
+                      :label="$t('settings.base.showMovieInfoCardOnSearch')"
                     ></v-switch>
 
                     <!-- 搜索方案切换的时候是否自动搜索 -->

--- a/src/options/views/settings/Sites/Editor.vue
+++ b/src/options/views/settings/Sites/Editor.vue
@@ -12,6 +12,17 @@
           :rules="rules.require"
         ></v-text-field>
 
+        <!--&lt;!&ndash;站点分组&ndash;&gt;-->
+        <!--<v-combobox-->
+        <!--    v-model="site.siteGroups"-->
+        <!--    hide-selected-->
+        <!--    :hint="$t('settings.sites.editor.siteGroup')"-->
+        <!--    :label="$t('settings.sites.editor.siteGroupTip')"-->
+        <!--    multiple-->
+        <!--    persistent-hint-->
+        <!--    small-chips-->
+        <!--&gt;</v-combobox>-->
+
         <!-- 标签 -->
         <v-combobox
           v-model="site.tags"


### PR DESCRIPTION
## 分组设置

* 从站点设置里面读取标签作为分组依据
* 设置优先级后, 标签顺序和站点默认排序按优先级从小到大
----
* `刷新我的数据`按钮已修改为 `刷新当前分组的数据`. 可以在处理完已读消息之后一键刷新
* 未选择分组, 或选择全部将返回所有站点
* 标签之间的关系是 **或**

## Todo
* 联动 时间轴 页面
* 调整下拉框高度
* 调整`打开刷新错误网站`和`打开未读消息`按钮的表现形式. 目前保留是为了提醒用户需要进一步处理
* 更新站点 config.json 的标签.
* 默认不选择标签的情况下, 会有样式问题,,, ~~选个所有就好了~~

## 截图
<img width="1124" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/19e66468-5c26-4b6f-a30f-036448674867">
<img width="1111" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/45d292b4-c483-4665-beb3-8986b2f753be">

