### PR TITLE
fix(ptvicomo):象站魔力修改为象草

### DIFF
--- a/resource/sites/ptvicomo.net/config.json
+++ b/resource/sites/ptvicomo.net/config.json
@@ -111,6 +111,15 @@
           ]
         }
       }
+    },
+    "userExtendInfo": {
+      "merge": true,
+      "fields": {
+        "bonus": {
+          "selector": ["td.rowhead:contains('象草') + td", "td.rowhead:contains('Lily') + td"],
+          "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+        }
+      }
     }
   },
   "searchEntryConfig": {


### PR DESCRIPTION
象站魔力修改为象草
![Snipaste_2023-10-13_16-13-57.png](https://s2.loli.net/2023/10/13/zTHtGdP9v6SoYWO.png)