### PR TITLE
Fix: 修复豆瓣Top 250页面无法搜索的问题

### DIFF
--- a/resource/publicSites/douban.com/top250.js
+++ b/resource/publicSites/douban.com/top250.js
@@ -20,10 +20,6 @@
       let title = "用 PT 助手搜索";
       let div = $("<div style='padding: 5px;margin-left: 20px;'/>").attr("title", `搜索 ${key}`).appendTo(parent);
       $("<a href='javascript:void(0);' class='lnk-sharing'/>").html(title).on("click", (event) => {
-        let match = parent.attr("href").match(/subject\/(\d+)/);
-        if (match && match.length >= 2) {
-          key = `douban${match[1]}`;
-        }
         let button = $(event.target);
         this.search(key, button);
       }).appendTo(div);


### PR DESCRIPTION
#1631 
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31879581/3c813b97-9940-4d54-baa9-fb4b838e1396)
在Top 250 页面点击后，用电影名称的方式搜索
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31879581/0780d6e4-6f75-4966-9305-799b5f7ff844)
