### PR TITLE
feat: use _ to indicate default savePath

### DIFF
--- a/resource/clients/qbittorrent/init.js
+++ b/resource/clients/qbittorrent/init.js
@@ -175,6 +175,8 @@
         formData.append("savepath", data.savePath)
         // 禁用自动管理种子
         autoTMM = false
+      } else {
+        savePath = "_"
       }
 
       if (clientOptions && clientOptions.enableCategory) {

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -586,7 +586,7 @@
           "tagIMDb": "Add IMDb tag when sending a torrent(Beta)",
           "enableCategory": "Automatically add QB categories when sending torrents (Beta)",
           "enableCategoryText": "QB category list",
-          "enableCategoryTextTip": "Fill in one address per line, with commas separating the category name and path. Path keywords are not supported. For example: 'movie,/tmp/movie'. You also need to fill in the same download path in the download directory settings. When the download path is specified and the download path hits a certain category, the category will be added and automatic seed management will be enabled.",
+          "enableCategoryTextTip": "Fill in one address per line, with commas separating the category name and path. Only support FULL PATH (e.g. movie,/tmp/movie) or '_' (e.g. movie,_) to represent qbit's default path. The category will be assigned if corresponding path matched user-selected one,with automatic seed management enabled.",
           "autoCreate": "<Automatically generated after saving>",
           "test": "Test if the server can connect",
           "testSuccess": "Server can be connected",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -582,7 +582,7 @@
           "tagIMDb": "发送种子时自动添加IMDb标签（Beta）",
           "enableCategory": "发送种子时自动添加 QB 分类 (Beta)",
           "enableCategoryText": "QB 分类列表",
-          "enableCategoryTextTip": "每行填写一个地址，逗号分隔分类名称和路径, 不支持路径关键字。如：'movie,/tmp/movie'. 还需在下载目录设置里面填写一样的下载路径. 当指定了下载路径且下载路径命中了某一个分类, 才会添加分类并启用自动种子管理.",
+          "enableCategoryTextTip": "每行填写一个地址，逗号分隔分类名称和路径, 不支持路径关键字。如：'movie,/tmp/movie'。默认分类请使用'movie,_'的格式。还需在下载目录设置里面填写一样的下载路径. 当指定了下载路径且下载路径命中了某一个分类, 才会添加分类并启用自动种子管理.",
           "autoCreate": "<保存后自动生成>",
           "test": "测试服务器是否可连接",
           "testSuccess": "服务器可连接",


### PR DESCRIPTION
打开”发送种子时自动添加QB分类功能“，在没有选择保存路径时无法定义分类名称，比如使用”一键下载“功能的时候。
这个patch允许使用类似下面的分类列表格式
```
默认分类,_
```
如果发送种子时没有指定保存路径将使用该行定义的分类名。