### PR TITLE
fix(ptvicomo):修复象站石墨显示

### DIFF
--- a/resource/sites/ptvicomo.net/config.json
+++ b/resource/sites/ptvicomo.net/config.json
@@ -120,6 +120,15 @@
           "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
         }
       }
+    },
+    "bonusExtendInfo": {
+      "prerequisites": "!user.bonusPerHour",
+      "page": "/mybonus.php",
+      "fields": {
+        "bonusPerHour": {
+          "selector": ["#outer td[rowspan]"]
+        }
+      }
     }
   },
   "searchEntryConfig": {


### PR DESCRIPTION
修复象站石墨显示
<img width="1124" alt="象" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/29299908/fcb8c6c6-7937-47f9-bd05-216517c99d92">
