### PR TITLE
fix(unit3d): call `filters.join()` only if `filters` is an array

### DIFF
--- a/src/background/infoParser.ts
+++ b/src/background/infoParser.ts
@@ -148,7 +148,12 @@ export class InfoParser {
           });
         }
         result = query;
-        console.log(`filter result for ${filters.join(" => ")}: ${result}`);
+
+        // be sure filters is an array
+        if (Array.isArray(filters)) {
+          console.log(`filter result for ${filters.join(" => ")}: ${result}`);
+        }
+
       } else {
         switch (rule.dataType) {
           case ERequestResultType.JSON:


### PR DESCRIPTION
This fix prevents unit3d sites from failing to retrieve search results. 