### PR TITLE
fix(BYR): Level Requirements and userBaseInfo Getting

### DIFF
--- a/resource/sites/byr.pt/config.json
+++ b/resource/sites/byr.pt/config.json
@@ -72,6 +72,47 @@
     "ratio": "4.55",
     "privilege": "更加高级"
   }],
+  "selectors": {
+      "userBaseInfo": {
+          "page": "/index.php",
+          "fields": {
+              "id": {
+                  "selector": [
+                      "a[href*='userdetails.php']:first"
+                  ],
+                  "attribute": "href",
+                  "filters": [
+                      "query?query.getQueryString('id'):''"
+                  ]
+              },
+              "name": {
+                  "selector": [
+                      "a[href*='userdetails.php']:first"
+                  ],
+                  "filters": [
+                      "query&&query.attr('href').getQueryString('id')>0?query.text():''"
+                  ]
+              },
+              "isLogged": {
+                  "selector": [
+                      "a[href*='usercp.php']"
+                  ],
+                  "filters": [
+                      "query.length>0"
+                  ]
+              },
+              "messageCount": {
+                  "selector": [
+                      "td[style*='background:red']a[href*='messages.php']"
+                  ],
+                  "filters": [
+                      "query.text().match(/(\\d+)/)",
+                      "(query&&query.length>=2)?parseInt(query[1]):0"
+                  ]
+              }
+          }
+      }
+  },
   "searchEntry": [{
       "entry": "/torrents.php?search=$key$&notnewword=1",
       "name": "全站",

--- a/resource/sites/byr.pt/config.json
+++ b/resource/sites/byr.pt/config.json
@@ -80,46 +80,46 @@
       "privilege": "可以领取专属荣誉徽章"
     }
 ],
-  "selectors": {
-      "userBaseInfo": {
-          "page": "/index.php",
-          "fields": {
-              "id": {
-                  "selector": [
-                      "a[href*='userdetails.php']:first"
-                  ],
-                  "attribute": "href",
-                  "filters": [
-                      "query?query.getQueryString('id'):''"
-                  ]
-              },
-              "name": {
-                  "selector": [
-                      "a[href*='userdetails.php']:first"
-                  ],
-                  "filters": [
-                      "query&&query.attr('href').getQueryString('id')>0?query.text():''"
-                  ]
-              },
-              "isLogged": {
-                  "selector": [
-                      "a[href*='usercp.php']"
-                  ],
-                  "filters": [
-                      "query.length>0"
-                  ]
-              },
-              "messageCount": {
-                  "selector": [
-                      "td[style*='background:red']a[href*='messages.php']"
-                  ],
-                  "filters": [
-                      "query.text().match(/(\\d+)/)",
-                      "(query&&query.length>=2)?parseInt(query[1]):0"
-                  ]
-              }
-          }
-      }
+"selectors": {
+    "userBaseInfo": {
+        "page": "/index.php",
+        "fields": {
+            "id": {
+                "selector": [
+                    "a[href*='userdetails.php']:first"
+                ],
+                "attribute": "href",
+                "filters": [
+                    "query?query.getQueryString('id'):''"
+                ]
+            },
+            "name": {
+                "selector": [
+                    "a[href*='userdetails.php']:first"
+                ],
+                "filters": [
+                    "query&&query.attr('href').getQueryString('id')>0?query.text():''"
+                ]
+            },
+            "isLogged": {
+                "selector": [
+                    "a[href*='usercp.php']"
+                ],
+                "filters": [
+                    "query.length>0"
+                ]
+            },
+            "messageCount": {
+                "selector": [
+                    "td[style*='background:red']a[href*='messages.php']"
+                ],
+                "filters": [
+                    "query.text().match(/(\\d+)/)",
+                    "(query&&query.length>=2)?parseInt(query[1]):0"
+                ]
+            }
+        }
+    }
   },
   "searchEntry": [{
       "entry": "/torrents.php?search=$key$&notnewword=1",

--- a/resource/sites/byr.pt/config.json
+++ b/resource/sites/byr.pt/config.json
@@ -16,62 +16,70 @@
     "bt.byr.cn"
   ],
   "levelRequirements": [{
-    "level": "1",
-    "name": "Power User",
-    "interval": "2",
-    "uploaded": "32GB",
-    "ratio": "1.05",
-    "privilege": "可以查看NFO文档；可以查看用户列表；可以请求续种；可以查看排行榜；可以查看其它用户的种子历史（如果用户隐私等级未设置为“强”）；可以删除自己上传的字幕"
-  },{
-    "level": "2",
-    "name": "Elite User",
-    "interval": "8",
-    "uploaded": "512GB",
-    "ratio": "1.55",
-    "privilege": "Elite User及以上用户封存账号后不会被删除；可以发送邀请；可以直接发布种子"
-  },{
-    "level": "3",
-    "name": "Crazy User",
-    "interval": "12",
-    "uploaded": "1024GB",
-    "ratio": "2.05",
-    "privilege": "可以在做种/下载/发布的时候选择匿名模式"
-  },{
-    "level": "4",
-    "name": "Insane User",
-    "interval": "24",
-    "uploaded": "2048GB",
-    "ratio": "2.55",
-    "privilege": "可以查看普通日志"
-  },{
-    "level": "5",
-    "name": "Veteran User",
-    "interval": "24",
-    "uploaded": "4096GB",
-    "ratio": "3.05",
-    "privilege": "可以查看其它用户的评论、帖子历史。Veteran User及以上的用户会永远保留账号"
-  },{
-    "level": "6",
-    "name": "Extreme User",
-    "interval": "24",
-    "uploaded": "8192GB",
-    "ratio": "3.55",
-    "privilege": "可以更新过期的外部信息"
-  },{
-    "level": "7",
-    "name": "Ultimate User",
-    "interval": "48",
-    "uploaded": "32768GB",
-    "ratio": "4.05",
-    "privilege": "更加高级"
-  },{
-    "level": "8",
-    "name": "Nexus Master",
-    "interval": "48",
-    "uploaded": "131072GB",
-    "ratio": "4.55",
-    "privilege": "更加高级"
-  }],
+      "level": "1",
+      "name": "PowerUser",
+      "interval": "2",
+      "uploaded": "32GB",
+      "ratio": "1.05",
+      "privilege": "可以上传字幕；可以发布趣味盒；可以查看用户列表；可以查看NFO文档；可以请求续种；可以查看排行榜；可以查看普通日志；可以删除自己上传的字幕；可以使用流量条；可以新增求种"
+    },
+    {
+      "level": "2",
+      "name": "EliteUser",
+      "interval": "8",
+      "uploaded": "512GB",
+      "ratio": "1.55",
+      "privilege": "可以查看其它用户的种子历史（如果用户隐私等级未设置为“强”）；可以直接发布种子"
+    },
+    {
+      "level": "3",
+      "name": "CrazyUser",
+      "interval": "12",
+      "uploaded": "1024GB",
+      "ratio": "2.05",
+      "privilege": "可以购买邀请；可以发送邀请；可以在做种/下载/发布的时候选择匿名模式"
+    },
+    {
+      "level": "4",
+      "name": "InsaneUser",
+      "interval": "24",
+      "uploaded": "2048GB",
+      "ratio": "2.55",
+      "privilege": "可以申请发布徽章；可以更新外部信息；可以购买用户名特效"
+    },
+    {
+      "level": "5",
+      "name": "VeteranUser",
+      "interval": "24",
+      "uploaded": "4096GB",
+      "ratio": "3.05",
+      "privilege": "可以查看其它用户的评论、帖子历史；可以查看种子结构"
+    },
+    {
+      "level": "6",
+      "name": "ExtremeUser",
+      "interval": "24",
+      "uploaded": "8192GB",
+      "ratio": "3.55",
+      "privilege": "可以购买用户名特效（动态）"
+    },
+    {
+      "level": "7",
+      "name": "UltimateUser",
+      "interval": "48",
+      "uploaded": "32768GB",
+      "ratio": "4.05",
+      "privilege": "更加高级"
+    },
+    {
+      "level": "8",
+      "name": "NexusMaster",
+      "interval": "48",
+      "uploaded": "131072GB",
+      "ratio": "4.55",
+      "privilege": "可以领取专属荣誉徽章"
+    }
+],
   "selectors": {
       "userBaseInfo": {
           "page": "/index.php",


### PR DESCRIPTION
解决了关于BYRBT站的两个问题：
1、更新了不同等级拥有的权限内容。包括升级赠送邀请数量、购买/发送邀请等级和购买昵称特效等等。
2、新增了正确获取BYRBT用户信息的代码。原先提交了issue，原来代码上传/下载/发布数据和注册日期等获取错乱，时魔数据符合网站，经网站论坛用户wireshark抓包，并批评网站首页的信息调查发现原来的代码是从首页index.php获取用户信息，新的昵称特效功能导致插件获取到了目前购买第一个竞价置顶的用户的信息，所以所有用户才会获取到错误的信息。

Two fixes about PTPP issues #1682 related to BYRBT:
1. Update level requirements level info: permissions owned by different levels (including invitation numbers given during upgrade, level required to buy/send an invitation and qualification to purchase nickname effects, etc.)
2. Add codes to get correct user info from BYRBT. I have sent an issue #1682 , as user information obtained by PTPP is incorrect, including upload/download size, uploaded torrents numbers and so on excpet points per hour. An enthusiastic user from our fourm reminded that the original code of PTPP only gets user information from BYRBT's index page(index.php). However, BYRBT conducts an update and introduce nickname effects. Thus, by tracking network requests, we find that PTPP will get the info of the user who purchased the first slot of top bidding. That is the reason why every user from BYRBT excpet him get the unexpected user info, I think.

