### PR TITLE
feat: 可将站点名称作为 tag 添加到 qb

### DIFF
--- a/resource/clients/qbittorrent/init.js
+++ b/resource/clients/qbittorrent/init.js
@@ -169,7 +169,8 @@
      */
     addTorrentFromUrl(data, callback) {
       let formData = new FormData();
-      let {savePath, category, clientOptions} = data, autoTMM = undefined, qbCategories
+      let {savePath, category, clientOptions, siteConfig} = data, autoTMM = undefined, qbCategories
+      let tags = [data.imdbId]
 
       if (savePath) {
         formData.append("savepath", data.savePath)
@@ -197,6 +198,21 @@
         }
       }
 
+      if (clientOptions && siteConfig)  {
+        // 以 frds 为例, 这里是 keepfrds
+        if (clientOptions.hostnameAsTag) {
+          let url = new URL(siteConfig.activeURL).hostname
+          let arr = url.split('.')
+          arr.pop()
+          tags.push(arr.pop())
+        }
+        // 以 frds 为例, 这里是 pt@keepfrds
+        if (clientOptions.siteNameAsTag) {
+          tags.push(siteConfig.name)
+        }
+      }
+      tags = tags.filter(_ => !!_).map(_ => _.toLowerCase()).join(',')
+
       if (autoTMM !== undefined) {
         formData.append("autoTMM", autoTMM);
       }
@@ -209,8 +225,8 @@
         formData.append("paused", !data.autoStart);
       }
 
-      if (data.imdbId != undefined) {
-        formData.append("tags", data.imdbId);
+      if (tags) {
+        formData.append("tags", tags);
       }
 
       if (data.upLoadLimit && data.upLoadLimit > 0) {

--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -587,6 +587,8 @@
           "loginPwd": "login password",
           "id": "ID",
           "autoStart": "Automatically start downloading when sending a torrent",
+          "hostnameAsTag": "Add lowercase host name to tags when sending torrents (Beta)",
+          "siteNameAsTag": "Add lowercase site name to tags when sending torrents (Beta)",
           "tagIMDb": "Add IMDb tag when sending a torrent(Beta)",
           "enableCategory": "Automatically add QB categories when sending torrents (Beta)",
           "enableCategoryText": "QB category list",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -583,6 +583,8 @@
           "autoStart": "发送种子时自动开始下载",
           "enabled": "是否启用",
           "tagIMDb": "发送种子时自动添加IMDb标签（Beta）",
+          "hostnameAsTag": "发送种子时将小写 host 添加到标签 (Beta)",
+          "siteNameAsTag": "发送种子时将小写站点名添加到标签 (Beta)",
           "enableCategory": "发送种子时自动添加 QB 分类 (Beta)",
           "enableCategoryText": "QB 分类列表",
           "enableCategoryTextTip": "每行填写一个地址，逗号分隔分类名称和路径, 不支持路径关键字。如：'movie,/tmp/movie'。默认分类请使用'movie,_'的格式。还需在下载目录设置里面填写一样的下载路径. 当指定了下载路径且下载路径命中了某一个分类, 才会添加分类并启用自动种子管理.",

--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -273,6 +273,7 @@ export default class Controller {
           imdbId: downloadOptions.tagIMDb ? downloadOptions.imdbId : null,
           upLoadLimit: siteConfig !== undefined ? siteConfig.upLoadLimit : null,
           clientOptions: clientConfig.options,
+          siteConfig,
         })
         .then((result: any) => {
           this.service.logger.add({

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -40,6 +40,8 @@ export interface DownloadClient {
   // 发送种子的时候发送分类
   enableCategory?: boolean;
   qbCategories?: QbCategory[];
+  hostnameAsTag?: boolean;
+  siteNameAsTag?: boolean;
 }
 
 /**

--- a/src/options/views/settings/DownloadClients/Editor.vue
+++ b/src/options/views/settings/DownloadClients/Editor.vue
@@ -51,6 +51,16 @@
             v-if="['qbittorrent'].includes(option.type)"
           ></v-switch>
 
+          <!--站点 host 作为 qb 标签-->
+          <v-switch
+              :label="$t('settings.downloadClients.editor.hostnameAsTag')"
+              v-model="option.hostnameAsTag"
+          ></v-switch>
+          <!--站点名 作为 qb 标签-->
+          <v-switch
+              :label="$t('settings.downloadClients.editor.siteNameAsTag')"
+              v-model="option.siteNameAsTag"
+          ></v-switch>
           <!--启用 qb 分类-->
           <v-switch
               :label="$t('settings.downloadClients.editor.enableCategory')"


### PR DESCRIPTION
#1621

### 功能
* 支持将 站点名称添加为 qb 标签

> 以 frds 为例, 小写 host 是 `keepfrds`, 小写站点名是 `pt@keepfrds`

<img width="828" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/eba55acf-5500-4217-9096-99d574ed3aca">
<img width="363" alt="image" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/ec0ba86c-ade7-4c55-9317-e6a4cfc887e7">

### 其他说明

* qb 4.6.1 webui 已经支持按 tracker host 对种子进行筛选, 没有手动打站点 tag 的必要
* 目前大站都支持 qb 4.6.1, 建议直接升级
* 而且 iyuu 辅种也不会打 tag, 但是有第三方脚本, 按需选择. https://github.com/pt-plugins/PT-Plugin-Plus/issues/1621#issuecomment-1769516259
