### PR TITLE
fix(u2): 修复非简体中文语言环境下上传量和下载量获取的问题

### DIFF
--- a/resource/sites/u2.dmhy.org/config.json
+++ b/resource/sites/u2.dmhy.org/config.json
@@ -264,6 +264,14 @@
         "bonus": {
           "selector": ["td.rowhead:contains('UCoin') + td"],
           "filters": ["query.text().replace(/,/g,'').match(/\\(([\\d.]+)/)", "(query && query.length>=2)?parseFloat(query[1]):null"]
+        },
+        "uploaded": {
+          "selector": [".color_uploaded"],
+          "filters": ["$(query[0].nextSibling).text().trim().sizeToNumber()"]
+        },
+        "downloaded": {
+          "selector": [".color_downloaded"],
+          "filters": ["$(query[0].nextSibling).text().trim().sizeToNumber()"]
         }
       }
     },


### PR DESCRIPTION
p.s. 根据 #515，测试了当下载量为 0 且语言不是简体中文时，此问题复现。

参考其它站点的配置文件，试着定义了一下选择器，本地测试了一下可以解决问题。