### PR TITLE
fix(BYR): 种子详情页"复制链接"不带passkey

### DIFF
--- a/resource/sites/byr.pt/config.json
+++ b/resource/sites/byr.pt/config.json
@@ -11,7 +11,7 @@
   ],
   "schema": "NexusPHP",
   "host": "byr.pt",
-  "collaborator": ["Rhilip", "yuanyiwei"],
+  "collaborator": ["Rhilip", "yuanyiwei", "hui-shao"],
   "formerHosts": [
     "bt.byr.cn"
   ],
@@ -119,6 +119,15 @@
                 ]
             }
         }
+    },
+    "/details.php": {
+      "merge": true,
+      "fields": {
+        "downloadURL": {
+          "selector": [ "a#tlink[data-clipboard-text*='passkey']" ],
+          "filters": [ "query.attr('data-clipboard-text')" ]
+        }
+      }
     }
   },
   "searchEntry": [{


### PR DESCRIPTION
修复了在 BYR 种子详情页点击“复制链接”按钮后，写入到剪切板的 URL 不含有 passkey 参数的问题。

已本地测试通过：
![2024-01-08_190548](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31568606/1f7ec984-d424-42a2-911f-624840fe2bd2)

暂未发现对其他功能造成影响。