### PR TITLE
feat(m-team): 补充账号保留规则

### DIFF
--- a/resource/sites/kp.m-team.cc/config.json
+++ b/resource/sites/kp.m-team.cc/config.json
@@ -46,14 +46,14 @@
     "interval": "20",
     "downloaded": "1000GB",
     "ratio": "6",
-    "privilege": "魔力值加成：+5%"
+    "privilege": "魔力值加成：+5%；封存帳號（在控制面板）後不會被刪除帳號"
   },{
     "level": "6",
     "name": "Extreme User",
     "interval": "24",
     "downloaded": "2000GB",
     "ratio": "7",
-    "privilege": "魔力值加成：+6%"
+    "privilege": "魔力值加成：+6%；永遠保留"
   },{
     "level": "7",
     "name": "Ultimate User",


### PR DESCRIPTION
补充 帳號保留規則 (Account Parking , Keeping Rules)

帳號保留規則 (Account Parking , Keeping Rules)

沒有流量的用戶（即上傳/下載資料都為0）在註冊 5 天後將被刪除帳號；
未封存帳號的用戶連續 40 天不登錄將被刪除帳號(已經刪除的帳號是不可能用任何手段恢復的，請自己設法重新註冊，以此為理由要求站方發邀請碼是不可能被接受的。“登錄”指訪問pt網站網頁並進行登入，單純做種不算登錄)；
封存帳號的用戶連續90 天不登錄將被刪除帳號；
府丞/Veteran User及以上等級用戶封存帳號（在控制面板）後不會被刪除帳號；
府尹/Extreme User及以上等級用戶會永遠保留。


## 内容说明
按账号保留规则补充升级后福利
