### PR TITLE
fix(ecustpt&cyanbug): bonusPerHour

### DIFF
--- a/resource/sites/cyanbug.net/config.json
+++ b/resource/sites/cyanbug.net/config.json
@@ -12,7 +12,8 @@
     "影视"
   ],
   "collaborator": [
-    "jinglekang"
+    "jinglekang",
+    "hui-shao"
   ],
   "levelRequirements": [
     {
@@ -241,22 +242,6 @@
           "filters": [
             "query.next().text().split(' (')[0].trim()",
             "dateTime(query).isValid()?dateTime(query).valueOf():query"
-          ]
-        }
-      }
-    },
-    "bonusExtendInfo": {
-      "prerequisites": "!user.bonusPerHour",
-      "page": "/mybonus.php",
-      "fields": {
-        "bonusPerHour": {
-          "selector": [
-            "div:contains('你当前每小时能获取'):last",
-            "div:contains('You are currently getting'):last",
-            "div:contains('你當前每小時能獲取'):last"
-          ],
-          "filters": [
-            "parseFloat(query.text().match(/[\\d.]+/)[0])"
           ]
         }
       }

--- a/resource/sites/ecustpt.eu.org/config.json
+++ b/resource/sites/ecustpt.eu.org/config.json
@@ -12,7 +12,8 @@
     "综合"
   ],
   "collaborator": [
-    "EasonWong"
+    "EasonWong",
+    "hui-shao"
   ],
   "levelRequirements": [
     {
@@ -330,22 +331,6 @@
           "filters": [
             "query.next().text().split(' (')[0].trim()",
             "dateTime(query).isValid()?dateTime(query).valueOf():query"
-          ]
-        }
-      }
-    },
-    "bonusExtendInfo": {
-      "prerequisites": "!user.bonusPerHour",
-      "page": "/mybonus.php",
-      "fields": {
-        "bonusPerHour": {
-          "selector": [
-            "div:contains('你当前每小时能获取'):last",
-            "div:contains('You are currently getting'):last",
-            "div:contains('你當前每小時能獲取'):last"
-          ],
-          "filters": [
-            "parseFloat(query.text().match(/[\\d.]+/)[0])"
           ]
         }
       }


### PR DESCRIPTION
修复时魔的获取。

原站点配置文件的 selector 获取的是基础时魔，未考虑加成。故删除具体站点配置文件中的选择器，回退到 NP 架构的通用选择器（`#outer td[rowspan]`），即可正确获取。

已在本地测试。