### PR TITLE
fix(byrpt): messageCount

### DIFF
--- a/resource/sites/byr.pt/config.json
+++ b/resource/sites/byr.pt/config.json
@@ -111,7 +111,8 @@
             },
             "messageCount": {
                 "selector": [
-                    "td[style*='background:red']a[href*='messages.php']"
+                    "div[style*='background: red'] a[href*='messages.php']",
+                    "td[style*='background:red'] a[href*='messages.php']"
                 ],
                 "filters": [
                     "query.text().match(/(\\d+)/)",


### PR DESCRIPTION
消息提示的元素从 td 又改回 div 了

测试结果如下：
![2024-02-12_112404](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31568606/5bb77c8f-b207-435c-bb28-adb9cd540218)
![2024-02-12_112450](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31568606/9e943d91-a861-4d2c-903c-747cfde1618f)
