### PR TITLE
feat: 支持在站点设置里面设置 token (fsm)

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -767,6 +767,8 @@
           "timezone": "Timezone",
           "upLoadLimit": "Upload limit",
           "upLoadLimitTip": "Upload limit (KB\/s), 0 or empty for no limit",
+          "authToken": "Authorization Token",
+          "authTokenTip": "Authorization Token",
           "enableQuickLink": "Enable QuickLink",
           "enableDefaultQuickLink": "Enable Default QuickLink",
           "quickLinkText": "Custom QuickLink Text",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -762,6 +762,8 @@
           "timezone": "时区",
           "upLoadLimit": "上传速度限制",
           "upLoadLimitTip": "上传速度限制 (KB/s), 0或不填 不限速",
+          "authToken": "鉴权 Token",
+          "authTokenTip": "鉴权 Token (一般无需填写",
           "enableQuickLink": "启用快捷链接",
           "enableDefaultQuickLink": "启用默认链接",
           "quickLinkText": "自定义快捷链接列表",

--- a/resource/sites/fsm.name/config.json
+++ b/resource/sites/fsm.name/config.json
@@ -2,7 +2,7 @@
   "name": "FSM",
   "timezoneOffset": "+0800",
   "description": "飞天拉面神教 - FSM",
-  "url": "https://fsm.name/",
+  "url": "https://api.fsm.name/",
   "tags": [ "成人" ],
   "schema": "Common",
   "host": "fsm.name",
@@ -77,20 +77,21 @@
   },
   "selectors": {
     "userBaseInfo": {
-      "page": "/Rules",
+      "page": "/Users/infos",
+      "dataType": "json",
+      "headers": {
+        "Authorization": "$site.authToken$"
+      },
       "fields": {
         "isLogged": {
           "selector": [ "a.adminUser" ],
           "filters": [ "query.length>0" ]
         },
         "name": {
-          "selector": [ "#header-navbar .dropdown-toggle" ],
-          "filters": [ "query.text().trim().replace(/工具\\s?/,'')" ]
+          "selector": [ "response.data.username" ]
         },
         "id": {
-          "selector": [ "a[href*='/Users/profile']" ],
-          "attribute": "href",
-          "filters": [ "query ? query.getQueryString('uid'):''" ]
+          "selector": [ "response.data.uid" ]
         },
         "messageCount": {
           "selector": [ "a[href='/Mail']" ],

--- a/src/background/user.ts
+++ b/src/background/user.ts
@@ -303,6 +303,18 @@ export class User {
           console.log(error);
         }
       }
+      if (headers && site) {
+        try {
+          for (const key in headers) {
+            if (headers.hasOwnProperty(key)) {
+              const value = headers[key];
+              headers[key] = PPF.replaceKeys(value, site, "site");
+            }
+          }
+        } catch (error) {
+          console.log(error);
+        }
+      }
 
       /**
        * 是否有脚本解析器

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -311,6 +311,8 @@ export interface Site {
   userQuickLinks?: UserQuickLink[];
   // 使用站点标签进行分组
   // siteGroups?: string[];
+  // token in headers
+  authToken?: string
 }
 
 /**

--- a/src/options/views/settings/Sites/Editor.vue
+++ b/src/options/views/settings/Sites/Editor.vue
@@ -153,6 +153,12 @@
                 :label="$t('settings.sites.editor.upLoadLimit')"
                 :placeholder="$t('settings.sites.editor.upLoadLimitTip')"
         ></v-text-field>
+        <!--token-->
+        <v-text-field
+                v-model="site.authToken"
+                :label="$t('settings.sites.editor.authToken')"
+                :placeholder="$t('settings.sites.editor.authTokenTip')"
+        ></v-text-field>
         <!-- 允许获取用户信息 -->
         <v-switch
           :label="$t('settings.sites.editor.allowGetUserInfo')"


### PR DESCRIPTION
* 支持在站点设置里面设置 token
* fsm token 过期太快，测试太麻烦, 先不做了。从截图里面可以看到用户数据是已经获取到了的
#1684

<img width="638" alt="截屏2024-02-12 13 10 52" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/33705067/def862e4-ea3b-40f4-9f1c-b54dfb3af725">
