### PR TITLE
fix(pig): messageCount

### DIFF
--- a/resource/sites/piggo.me/config.json
+++ b/resource/sites/piggo.me/config.json
@@ -103,6 +103,15 @@
     }],
     "collaborator": "koal",
     "selectors": {
+        "userBaseInfo": {
+            "merge": true,
+            "fields": {
+                "messageCount": {
+                    "selector": ["div[id^='messages']"],
+                    "filters": ["parseInt(query.text().match(/(\\d+)/))"]
+                }
+            }
+        },
         "userSeedingTorrents": {
             "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
             "fields": {


### PR DESCRIPTION
适配站点，新增一个 selector。

猪站的界面不太一样，故使用 NP 架构的选择器匹配不到。

本地已测试，功能正常。
