### PR TITLE
fix(nexusphp): 处理unsatisfieds(HnR)时在无数据时会抛出错误

### DIFF
--- a/resource/schemas/NexusPHP/config.json
+++ b/resource/schemas/NexusPHP/config.json
@@ -116,7 +116,7 @@
         },
         "unsatisfieds": {
           "selector": ["a[href*='myhr.php']:last"],
-          "filters": ["query ? parseInt(query.text().match(/[\\d.]+/)[0]) : null"]
+          "filters": ["query.length ? parseInt(query.text().match(/[\\d.]+/)[0]) : null"]
         }
       }
     },


### PR DESCRIPTION
这个错误不会影响前台，但会在background page中出现错误记录。

<img width="1102" alt="Pasted Graphic" src="https://github.com/pt-plugins/PT-Plugin-Plus/assets/20028238/3ab121b0-16d9-472e-93c6-0df7a540c369">

如图所示，当网页中不存在H&R信息时，选择器仍会返回一个Object，因此需要通过Object中的length属性判断是否有数据。