### PR TITLE
feat: add AN, DCC, SBS, LC, TT

### DIFF
--- a/resource/sites/audionews.org/config.json
+++ b/resource/sites/audionews.org/config.json
@@ -1,0 +1,105 @@
+{
+  "name": "Audionews",
+  "timezoneOffset": "+0800",
+  "description": "AN",
+  "url": "https://audionews.org/",
+  "icon": "https://audionews.org/favicon.ico",
+  "tags": ["软件", "0day"],
+  "schema": "Common",
+  "host": "audionews.org",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/viewtopic.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/tracker.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/torrents.js"]
+  }],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/index.php",
+      "fields": {
+        "id": {
+          "selector": ["a.user_photo[title='Your profile']"],
+          "attribute": "href",
+          "filters": ["query ? query.getQueryString('u'):''"]
+        },
+        "isLogged": {
+          "selector": ["a[href*='./login.php?logout=1']"],
+          "filters": ["query.length>0"]
+        },
+        "uploaded": {
+          "selector": ["dt:contains('Uploaded') + dd.seedmed"],
+          "filters": ["query.text().trim().sizeToNumber()"]
+        },
+        "downloaded": {
+          "selector": ["dd.leechmed"],
+          "filters": ["query.text().trim().sizeToNumber()"]
+        },
+        "ratio": {
+          "selector": ["dl.pairsUser_ratio > dt:contains('Ratio') + dd"]
+        },
+        "seedingSize": {
+          "value": -1
+        },
+        "bonus": {
+          "value":"N/A"
+        },
+        "bonusPerHour": {
+          "value":"N/A"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/profile.php?mode=viewprofile&u=$user.id$",
+      "fields": {
+        "name": {
+          "selector": ["h4#username > span"]
+        },
+        "levelName": {
+          "selector": ["b#rank-name"]
+        },
+        "joinTime": {
+          "selector": ["td#user_regdate > span"],
+          "filters": [
+            "query.text().split(' (')[0]", "dateTime(query).isValid()?dateTime(query).valueOf():query"
+          ]
+        },
+        "seeding": {
+          "selector": ["span.dls-cnt"],
+          "filters": [
+            "query.text().match(/Seed: (\\d+)/)[1]"
+          ]
+        },
+        "uploads": {
+          "selector": ["span.dls-cnt"],
+          "filters": [
+            "query.text().match(/Self: (\\d+)/)[1]"
+          ]
+        }
+      }
+    },
+    "common": {
+      "page": "/viewtopic.php",
+      "fields": {
+        "downloadURL": {
+          "selector": ["a.genmed[href*='dl.php?id=']"],
+          "filters": ["query.attr('href')"]
+        },
+        "size": {
+          "selector": ["tr.row1 > td:contains('Size:') + td"],
+          "filters": ["query.text().replace(/,/g,'').sizeToNumber()"]
+        },
+        "downloadURLs": {
+          "selector": ["a.genmed[title='Download'][href*='dl.php?id=']"],
+          "filters": ["query.toArray()"]
+        },
+        "confirmSize": {
+          "selector": ["tr td:nth-child(9)"],
+          "filters": ["query"]
+        }
+      }
+    }
+  }
+}

--- a/resource/sites/digitalcore.club/config.json
+++ b/resource/sites/digitalcore.club/config.json
@@ -1,0 +1,133 @@
+{
+  "name": "DigitalCore.Club",
+  "timezoneOffset": "+0800",
+  "description": "DCC",
+  "url": "https://digitalcore.club/",
+  "icon": "https://digitalcore.club/favicon.ico",
+  "tags": [
+    "综合"
+  ],
+  "schema": "Common",
+  "host": "digitalcore.club",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/torrent/"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/search","/alltorrents","/xxx","/movies","/music","/tvseries","/apps","/games"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/torrents.js"]
+  }],
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "Sentinel",
+      "interval": "14D",
+      "uploaded": "50GB",
+      "ratio": "1.05",
+      "privilege": "You get access to the request system and the bonus system. You can upload (moderated) torrents."
+    },
+    {
+      "level": 2,
+      "name": "Viceroy",
+      "interval": "105D",
+      "uploaded": "300GB",
+      "ratio": "1.10",
+      "privilege": "All of the above. See all 'top' lists. See extended statistics. IP logging disabled. All IP logs are now cleared."
+    },
+    {
+      "level": 3,
+      "name": "Sentry",
+      "interval": "210D",
+      "uploaded": "1200GB",
+      "ratio": "1.10",
+      "privilege": "All of the above. You get 3 request slots, 2 invites and above perks."
+    },
+    {
+      "level": 4,
+      "name": "Guardian",
+      "interval": "500D",
+      "uploaded": "5TB",
+      "ratio": "20.00",
+      "privilege": "All of the above, plus 5 extra invites and 6 additional request slots. Can upload unmoderated torrents."
+    },
+    {
+      "level": 5,
+      "name": "Vanguard",
+      "interval": "730D",
+      "uploaded": "20TB",
+      "ratio": "20.00",
+      "privilege": "All of the above, plus 10 extra invites and 10 additional request slots. Can upload unmoderated torrents."
+    }
+  ],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/api/v1/status",
+      "dataType": "json",
+      "fields": {
+        "bonus": { "selector": ["user.bonuspoang"]},
+        "downloaded": { "selector": ["user.downloaded"]},
+        "id": { "selector": ["user.id"]},
+        "levelName": { 
+          "selector": ["user.class"],
+          "filters": [
+            "['Rogue', 'Sentinel', 'Viceroy', 'Sentry', 'Guardian', 'Vanguard'][query]"
+          ]
+        },
+        "name": { "selector": ["user.username"]},
+        "uploaded": { "selector": ["user.uploaded"]},
+        "messageCount": { "selector": ["user.newMessages"]},
+        "bonusPerHour": {
+          "value":"N/A"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/api/v1/users/$user.id$",
+      "dataType": "json",
+      "fields": {
+        "joinTime": {
+          "selector": [
+            "added"
+          ],
+          "filters": [
+            "dateTime(query).isValid()?dateTime(query).valueOf():query"
+          ]
+        }
+      }
+    },
+    "userSeedingTorrents": {
+      "page": "/api/v1/users/$user.id$/peers",
+      "dataType": "json",
+      "fields": {
+          "seedingSize": {
+            "selector": ["seeding.reduce((acc, cur) => acc + cur.size, 0)"]
+          },
+          "seeding": {
+            "selector": ["seeding.length"]
+          }
+      }
+    },
+    "common": {
+      "page": "/torrent",
+      "fields": {
+        "downloadURL": {
+          "selector": ["a:has(i.fa.fa-link)"],
+          "filters": ["query.attr('href')"]
+        },
+        "size": {
+          "selector": ["td[translate='TORRENTS.SIZE']:contains('Size') + td"],
+          "filters": ["query.text().replace(/,/g,'').sizeToNumber()"]
+        },
+        "downloadURLs": {
+          "selector": ["a:has(i.fa.fa-download)"],
+          "filters": ["query.toArray()"]
+        },
+        "confirmSize": {
+          "selector": ["td[ng-if=\"vm.colSize == 'true'\"]"],
+          "filters": ["query.contents().eq(0)"]
+        }
+      }
+    }
+  }
+}

--- a/resource/sites/login.superbits.org/config.json
+++ b/resource/sites/login.superbits.org/config.json
@@ -1,0 +1,125 @@
+{
+  "name": "SuperBits",
+  "timezoneOffset": "+0100",
+  "description": "SBS",
+  "url": "https://login.superbits.org/",
+  "icon": "https://login.superbits.org/favicon.ico",
+  "tags": [
+    "综合"
+  ],
+  "schema": "Common",
+  "host": "login.superbits.org",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/torrent/"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/search","/nytt","/allt","/xxx","/p2p","/musik","/tvserier","/arkiv"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/torrents.js"]
+  }],
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "Fullvärdig medlem",
+      "interval": "14D",
+      "uploaded": "50GB",
+      "ratio": "1.05",
+      "privilege": "Can make and upload requests, use the bonus system and other features of the site."
+    },
+    {
+      "level": 2,
+      "name": "Trogen medlem",
+      "interval": "15",
+      "uploaded": "100GB",
+      "ratio": "1.10",
+      "privilege": "Access to all Top Lists and you have access to the invite system. All IP logs are deleted and IP logging is turned off."
+    },
+    {
+      "level": 3,
+      "name": "Veteran",
+      "interval": "30",
+      "uploaded": "1.2TB",
+      "ratio": "1.10",
+      "privilege": "Can see the Veteran forum."
+    },
+    {
+      "level": 4,
+      "name": "Legend",
+      "interval": "3Y",
+      "uploaded": "30TB",
+      "ratio": "2.10",
+      "privilege": "Access to most things."
+    }
+  ],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/api/v1/status",
+      "dataType": "json",
+      "fields": {
+        "bonus": { "selector": ["user.bonuspoang"]},
+        "downloaded": { "selector": ["user.downloaded"]},
+        "id": { "selector": ["user.id"]},
+        "levelName": { 
+          "selector": ["user.class"],
+          "filters": [
+            "['Medlem', 'Fullvärdig medlem', 'Trogen medlem', 'Veteran', 'Legend'][query]"
+          ]
+        },
+        "name": { "selector": ["user.username"]},
+        "uploaded": { "selector": ["user.uploaded"]},
+        "messageCount": { "selector": ["user.newMessages"]},
+        "bonusPerHour": {
+          "value":"N/A"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/api/v1/users/$user.id$",
+      "dataType": "json",
+      "fields": {
+        "joinTime": {
+          "selector": [
+            "added"
+          ],
+          "filters": [
+            "dateTime(query).isValid()?dateTime(query).valueOf():query"
+          ]
+        }
+      }
+    },
+    "userSeedingTorrents": {
+      "page": "/api/v1/users/$user.id$/peers",
+      "dataType": "json",
+      "fields": {
+          "seedingSize": {
+            "selector": ["seeding.reduce((acc, cur) => acc + cur.size, 0)"]
+          },
+          "seeding": {
+            "selector": ["seeding.length"]
+          }
+      }
+    },
+    "common": {
+      "page": "/torrent",
+      "fields": {
+        "downloadURL": {
+          "selector": ["a:has(i.fa.fa-link)"],
+          "filters": ["query.attr('href')"]
+        },
+        "size": {
+          "selector": ["td[translate='TORRENTS.SIZE']:contains('Size') + td"],
+          "filters": ["query.text().replace(/,/g,'').sizeToNumber()"]
+        },
+        "downloadURLs": {
+          "selector": ["a:has(i.fa.fa-download)"],
+          "filters": ["query.toArray()"]
+        },
+        "confirmSize": {
+          "selector": ["td[ng-if=\"vm.colSize == 'true'\"]"],
+          "filters": ["query.contents().eq(0)"]
+        }
+      }
+    }
+  }
+}

--- a/resource/sites/losslessclub.com/config.json
+++ b/resource/sites/losslessclub.com/config.json
@@ -1,0 +1,110 @@
+{
+  "name": "LosslessClub",
+  "timezoneOffset": "+0000",
+  "description": "LC",
+  "url": "https://losslessclub.com/",
+  "icon": "https://losslessclub.com/favicon.ico",
+  "tags": ["音乐"],
+  "schema": "Common",
+  "host": "losslessclub.com",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/details.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/browse.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/torrents.js"]
+  }],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/index.php",
+      "fields": {
+        "id": {
+          "selector": ["span.bar_user_welcome + b > a[href*='userdetails.php']"],
+          "attribute": "href",
+          "filters": ["query ? query.getQueryString('id'):''"]
+        },
+        "name": {
+          "selector": ["span.bar_user_welcome + b > a[href*='userdetails.php'] > span"]
+        },
+        "isLogged": {
+          "selector": ["a[href*='logout.php']"],
+          "filters": ["query.length>0"]
+        },
+        "uploaded": {
+          "selector": ["td.bottom.bar_user:first > span.smallfont"],
+          "filters": ["query.contents().eq(18).text().trim().sizeToNumber()"]
+        },
+        "downloaded": {
+          "selector": ["td.bottom.bar_user:first > span.smallfont"],
+          "filters": ["query.contents().eq(20).text().replace('|','').trim().sizeToNumber()"]
+        },
+        "ratio": {
+          "selector": ["span.bar_user_ratio"],
+          "filters": ["query.next().text()"]
+        },
+        "seeding": {
+          "selector": ["td.bottom.bar_user:first > span.smallfont"],
+          "filters": [
+            "query.contents().eq(24).text().trim()"
+          ]
+        },
+        "bonus": {
+          "selector": ["td.bottom.bar_user a[href*='mybonus.php']"]
+        },
+        "bonusPerHour": {
+          "value":"N/A"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "fields": {
+        "levelName": {
+          "selector": ["td:contains('Класс') + td"]
+        },
+        "joinTime": {
+          "selector": ["td:contains('Зарегистрирован') + td"],
+          "filters": [
+            "query.text().split(' (')[0]", "dateTime(query).isValid()?dateTime(query).valueOf():query"
+          ]
+        }
+      }
+    },
+    "userSeedingTorrents": {
+      "page": "/userdetails.i.php?ajax=&id=$user.id$&do=torrents-seeding",
+      "fields": {
+          "seedingSize": {
+            "selector": ["tr:not(:eq(0))"],
+            "filters": ["jQuery.map(query.find('td:eq(2)'), (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+          }
+      }
+    },
+    "common": {
+      "page": "/details.php",
+      "fields": {
+        "downloadURL": {
+          "selector": ["a[alt='Download'][href*='download.php?id=']"],
+          "filters": ["query.attr('href')"]
+        },
+        "size": {
+          "selector": ["td.heading:contains('Size') + td"],
+          "filters": ["parseFloat(query.text().match(/\\(([^)]+)\\)/)[1].replace(/,/g, ''))"]
+        },
+        "sayThanksButton": {
+          "selector": ["input[value='Thanks']"],
+          "filters": ["query"]
+        },
+        "downloadURLs": {
+          "selector": ["a:has(img[src='pic/download.gif'])"],
+          "filters": ["query.toArray()"]
+        },
+        "confirmSize": {
+          "selector": ["tr td:not(.colhead, .pager):nth-child(5)"],
+          "filters": ["query"]
+        }
+      }
+    }
+  }
+}

--- a/resource/sites/losslessclub.com/config.json
+++ b/resource/sites/losslessclub.com/config.json
@@ -62,10 +62,10 @@
       "page": "/userdetails.php?id=$user.id$",
       "fields": {
         "levelName": {
-          "selector": ["td:contains('Класс') + td"]
+          "selector": ["td.rowhead:contains('Класс') + td"]
         },
         "joinTime": {
-          "selector": ["td:contains('Зарегистрирован') + td"],
+          "selector": ["td.rowhead:contains('Зарегистрирован') + td"],
           "filters": [
             "query.text().split(' (')[0]", "dateTime(query).isValid()?dateTime(query).valueOf():query"
           ]

--- a/resource/sites/www.trancetraffic.com/config.json
+++ b/resource/sites/www.trancetraffic.com/config.json
@@ -1,0 +1,139 @@
+{
+  "name": "TranceTraffic",
+  "timezoneOffset": "+0800",
+  "description": "TT",
+  "url": "https://www.trancetraffic.com/",
+  "icon": "https://www.trancetraffic.com/favicon.ico",
+  "tags": [
+    "音乐"
+  ],
+  "schema": "Common",
+  "host": "www.trancetraffic.com",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/details.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/browse.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/torrents.js"]
+  }],
+  "levelRequirements": [
+    {
+      "level": 1,
+      "name": "Power User",
+      "interval": "4",
+      "uploaded": "25GB",
+      "ratio": "1.05",
+      "privilege": "Can view ReadMe files."
+    }
+  ],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/index.php",
+      "fields": {
+        "id": {
+          "selector": [
+            "a[href*='userdetails.php']:first"
+          ],
+          "attribute": "href",
+          "filters": [
+            "query ? query.getQueryString('id'):''"
+          ]
+        },
+        "name": {
+          "selector": [
+            "a[href*='userdetails.php']:first"
+          ]
+        },
+        "isLogged": {
+          "selector": [
+            "a[href*='logout.php']"
+          ],
+          "filters": [
+            "query.length>0"
+          ]
+        },
+        "uploaded": {
+          "selector": [
+            "span:contains('Uploaded:') + span"
+          ],
+          "filters": [
+            "query.text().trim().replace(/,/g,'').sizeToNumber()"
+          ]
+        },
+        "downloaded": {
+          "selector": [
+            "span:contains('Downloaded:') + span"
+          ],
+          "filters": [
+            "query.text().trim().replace(/,/g,'').sizeToNumber()"
+          ]
+        },
+        "ratio": {
+          "selector": [
+            "span:contains('Ratio:') + span"
+          ]
+        },
+        "seeding": {
+          "selector": [
+            "img[alt='Torrents seeding'] + span"
+          ]
+        },
+        "seedingSize": {
+          "value": -1
+        },
+        "bonus": {
+          "value": "N/A"
+        },
+        "bonusPerHour": {
+          "value": "N/A"
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "fields": {
+        "levelName": {
+          "selector": [
+            "td.rowhead:contains('Class') + td"
+          ]
+        },
+        "joinTime": {
+          "selector": [
+            "td.rowhead:contains('Join date') + td"
+          ],
+          "filters": [
+            "query.text().split(' (')[0]",
+            "dateTime(query).isValid()?dateTime(query).valueOf():query"
+          ]
+        }
+      }
+    },
+    "common": {
+      "page": "/details.php",
+      "fields": {
+        "downloadURL": {
+          "selector": ["td.heading:contains('Download') + td > a"],
+          "filters": ["query.attr('href')"]
+        },
+        "size": {
+          "selector": ["td.heading:contains('Size') + td"],
+          "filters": ["parseFloat(query.text().match(/\\(([^)]+)\\)/)[1].replace(/,/g, ''))"]
+        },
+        "sayThanksButton": {
+          "selector": ["#thanks-checkbox"],
+          "filters": ["query"]
+        },
+        "downloadURLs": {
+          "selector": ["a[href*='download.php']"],
+          "filters": ["query.toArray()"]
+        },
+        "confirmSize": {
+          "selector": ["table[border='1'] tr td:not(.colhead):nth-child(7)"],
+          "filters": ["query"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
只做了获取用户信息、种子详情页发送到下载器、种子列表批量处理三个功能的适配。没有适配搜索功能。均已测试过能正常使用。

DCC与SBS使用的架构相同，均为rartracker，因为是前后端分离，种子详情页功能可能会出现插件运行早于api获取种子信息，导致获取到的种子体积为0的情况。考虑过要不要单独调用api获取种子体积，但感觉这么额外调用一次不太好，不知道有无较好的解决方案。

SBS的主域名是www.superbits.org，但目前访问会被强制跳转到login.superbits.org，除非手动将login.*的cookie复制到www.*上，否则正常是完全无法访问主域名的。因此我直接用了login.superbits.org作为主域名。