### PR TITLE
fix(user): do not set the cache value globally for user info ajax req…

### DIFF
--- a/src/background/user.ts
+++ b/src/background/user.ts
@@ -333,8 +333,7 @@ export class User {
         data: rule.requestContentType == "application/json" ? JSON.stringify(requestData) : requestData,
         contentType: rule.requestContentType == "application/json" ? "application/json" : "application/x-www-form-urlencoded",
         headers: rule.headers,
-        timeout: this.service.options.connectClientTimeout || 30000,
-        cache: false
+        timeout: this.service.options.connectClientTimeout || 30000
       })
         .done(result => {
           this.removeQueue(host, url);


### PR DESCRIPTION
fix(user): do not set the cache value globally for user info ajax request.
Do not set the cache value globally for user info ajax request, which fails the data getting of the seeding/seedingsize for some sites such as TorrentLeech.
fixes https://github.com/pt-plugins/PT-Plugin-Plus/issues/1741
