### PR TITLE
修复FSM无法下载种子的bug同时修改启动网址允许从ptpp打开fsm网址而不是打开api.fsm

### DIFF
--- a/resource/sites/fsm.name/config.json
+++ b/resource/sites/fsm.name/config.json
@@ -1,8 +1,8 @@
 {
   "name": "FSM",
   "timezoneOffset": "+0800",
-  "description": "飞天拉面神教 - FSM",
-  "url": "https://api.fsm.name/",
+  "description": "飞天拉面神教 - FSM - 需要填写鉴权TOKEN",
+  "url": "https://fsm.name/",
   "tags": [ "成人" ],
   "schema": "common",
   "host": "fsm.name",
@@ -14,6 +14,7 @@
     "Ted423",
     "IITII",
     "tedzhu",
+    "joker",
     "Banxia"
   ],
   "plugins": [
@@ -30,7 +31,7 @@
   ],
   "searchEntryConfig": {
     "skipIMDbId": true,
-    "page": "/Torrents?type=0&systematics=0&keyword=$key$",
+    "page": "/api/Torrents?type=0&systematics=0&keyword=$key$",
     "loggedRegex": "container-fluid",
     "resultType": "html",
     "resultSelector": "table",
@@ -79,7 +80,7 @@
   },
   "selectors": {
     "userBaseInfo": {
-      "page": "/Users/infos",
+      "page": "/api/Users/infos",
       "dataType": "json",
       "requestMethod": "POST",
       "headers": {
@@ -110,7 +111,7 @@
           "value": "1711715887"
         },
         "bonusPerHour": {
-          "value": "未知算法，注册时间也未知随便填写一个方便ptpp出图"
+          "value": "未知，注册时间也未知"
         },
         "downloaded": {
           "selector": ["data.download"],
@@ -119,7 +120,7 @@
       }
     },
     "userExtendInfo":{
-      "page": "/Users/profile?uid=$user.id$",
+      "page": "/api/Users/profile?uid=$user.id$",
       "dataType": "json",
       "requestMethod": "POST",
       "headers": {
@@ -139,12 +140,7 @@
       }
     },
       "userSeedingTorrents": {
-        "page": "/Torrents/mySeed",
-        "dataType": "json",
-        "requestMethod": "POST",
-        "headers": {
-          "APITOKEN": "$site.authToken$"
-        },
+        "page": "/api/Torrents/mySeed",
         "fields": {
           "seedingSize": {
             "selector": ".panel-primary .panel-body td(6)",
@@ -155,12 +151,7 @@
         }
       },
     "common": {
-      "page": "/Torrents",
-      "dataType": "json",
-      "requestMethod": "POST",
-      "headers": {
-        "APITOKEN": "$site.authToken$"
-      },
+      "page": "/api/Torrents",
       "fields": {
         "downloadURL": {
           "selector": [ "a[href*='/Torrents/download']" ],

--- a/resource/sites/fsm.name/config.json
+++ b/resource/sites/fsm.name/config.json
@@ -1,7 +1,7 @@
 {
   "name": "FSM",
   "timezoneOffset": "+0800",
-  "description": "飞天拉面神教 - FSM - 需要填写鉴权TOKEN",
+  "description": "飞天拉面神教 - FSM",
   "url": "https://fsm.name/",
   "tags": [ "成人" ],
   "schema": "common",


### PR DESCRIPTION
##  说明

feat: 修改api.fsm为fsm.xx/api,保证功能前提下允许从ptpp打开fsm网址
修复：修复上个版本造成​​无法下载种子的bug

## 内容说明

1.将原本的api.fsm改为修改api.fsm为fsm.xx/api,保证功能前提下允许从ptpp打开fsm网址
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/35516655/4b75c266-1fcc-4967-8d1f-5954ed82f79f)
![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/35516655/9e990ccd-4f7c-41a8-b10f-07fadfe3428b)
2.修复上次提交在某些不该放token的位置放了token导致无法正常下载


