### PR TITLE
修复火狐浏览器不支持extraHeaders的问题

### DIFF
--- a/src/background/service.ts
+++ b/src/background/service.ts
@@ -6,6 +6,7 @@ import {
   ELogEvent,
   Site,
   SiteSchema,
+  EBrowserType,
   Dictionary,
   EUserDataRequestStatus,
   LogItem, EAlarm
@@ -608,6 +609,17 @@ export default class PTPlugin {
       }
     });
 
+    let opt_extraInfoSpec: string[] = [];
+
+    switch (PPF.browserName) {
+      case EBrowserType.Chrome:
+        opt_extraInfoSpec = ["requestHeaders", "blocking", "extraHeaders"];
+        break;
+      case EBrowserType.Firefox:
+        opt_extraInfoSpec = ["requestHeaders", "blocking"];
+        break;
+    }
+
     chrome.webRequest.onBeforeSendHeaders.addListener(
       (details: chrome.webRequest.WebRequestHeadersDetails) => {
         let headers: chrome.webRequest.HttpHeader[] = [];
@@ -625,8 +637,7 @@ export default class PTPlugin {
       },
       {
         urls: ["<all_urls>"]
-      },
-      ["requestHeaders", "blocking", "extraHeaders"]
+      },opt_extraInfoSpec
     );
 
   }


### PR DESCRIPTION
#1840 

![image](https://github.com/pt-plugins/PT-Plugin-Plus/assets/31879581/e2cdec52-0cdf-4c55-9980-28a4889e6751)
修复后可以正常打开