### PR TITLE
feat(u3d): seeding status

### DIFF
--- a/resource/schemas/UNIT3D/config.json
+++ b/resource/schemas/UNIT3D/config.json
@@ -29,10 +29,14 @@
       "progress": {
         "selector": [
           "span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, i.fas.fa-thumbs-down",
-          ".fa-do-not-enter",
+          "span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons, span.torrent-icons > i.fa-arrow-circle-down.text-danger.torrent-icons",
           ""
         ],
-        "switchFilters": [["100"], ["0"], ["null"]]
+        "switchFilters": [
+          ["100"],
+          ["0"],
+          ["null"]
+        ]
       },
       "status": {
         "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons", "span.torrent-icons > i.fa-arrow-circle-down.text-danger.torrent-icons", "span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", "span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons"],

--- a/resource/schemas/UNIT3D/config.json
+++ b/resource/schemas/UNIT3D/config.json
@@ -27,7 +27,7 @@
     }],
     "fieldSelector": {
       "progress": {
-        "selector": ["button.btn.btn-success.btn-circle, i[title*='Seeding']", "button.btn.btn-warning.btn-circle, button.btn.btn-info.btn-circle", ""],
+        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", "span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", ""],
         "switchFilters": [
           ["100"],
           ["0"],
@@ -35,11 +35,9 @@
         ]
       },
       "status": {
-        "selector": ["button.btn.btn-success.btn-circle, i[title*='Currently Seeding']", "button.btn.btn-warning.btn-circle", "button.btn.btn-info.btn-circle", "i[title*='Completed']"],
+        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons", "span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons"],
         "switchFilters": [
           ["2"],
-          ["1"],
-          ["3"],
           ["255"]
         ]
       }

--- a/resource/schemas/UNIT3D/config.json
+++ b/resource/schemas/UNIT3D/config.json
@@ -27,10 +27,9 @@
     }],
     "fieldSelector": {
       "progress": {
-        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", "span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", ""],
+        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", ""],
         "switchFilters": [
           ["100"],
-          ["0"],
           ["null"]
         ]
       },

--- a/resource/schemas/UNIT3D/config.json
+++ b/resource/schemas/UNIT3D/config.json
@@ -27,17 +27,20 @@
     }],
     "fieldSelector": {
       "progress": {
-        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", ""],
-        "switchFilters": [
-          ["100"],
-          ["null"]
-        ]
+        "selector": [
+          "span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, i.fas.fa-thumbs-down",
+          ".fa-do-not-enter",
+          ""
+        ],
+        "switchFilters": [["100"], ["0"], ["null"]]
       },
       "status": {
-        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons", "span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons"],
+        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons", "span.torrent-icons > i.fa-arrow-circle-down.text-danger.torrent-icons", "span.torrent-icons > i.fas.fa-thumbs-down.text-warning.torrent-icons", "span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons"],
         "switchFilters": [
           ["2"],
-          ["255"]
+          ["1"],
+          ["255"],
+          ["3"]
         ]
       }
     },

--- a/resource/schemas/UNIT3D/getSearchResult.js
+++ b/resource/schemas/UNIT3D/getSearchResult.js
@@ -258,7 +258,7 @@
         }
         result = cell.text().trim();
       }
-      if(result == "")return null;
+      if(result === "")return null;
       return result;
     }
   }

--- a/resource/sites/aither.cc/config.json
+++ b/resource/sites/aither.cc/config.json
@@ -49,23 +49,5 @@
       "uploaded": "40TiB",
       "privilege": "Mod Q skip, Special FL, Invite Forum, Sparkly name, HnR immunity"
     }
-  ],
-  "searchEntryConfig": {
-    "fieldSelector": {
-      "progress": {
-        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons", ""],
-        "switchFilters": [
-          ["100"],
-          ["null"]
-        ]
-      },
-      "status": {
-        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons", "span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons"],
-        "switchFilters": [
-          ["2"],
-          ["255"]
-        ]
-      }
-    }
-  }
+  ]
 }

--- a/resource/sites/aither.cc/config.json
+++ b/resource/sites/aither.cc/config.json
@@ -49,5 +49,23 @@
       "uploaded": "40TiB",
       "privilege": "Mod Q skip, Special FL, Invite Forum, Sparkly name, HnR immunity"
     }
-  ]
+  ],
+  "searchEntryConfig": {
+    "fieldSelector": {
+      "progress": {
+        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons, span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons", ""],
+        "switchFilters": [
+          ["100"],
+          ["null"]
+        ]
+      },
+      "status": {
+        "selector": ["span.torrent-icons > i.fas.fa-arrow-circle-up.text-success.torrent-icons", "span.torrent-icons > i.fas.fa-do-not-enter.torrent-icons"],
+        "switchFilters": [
+          ["2"],
+          ["255"]
+        ]
+      }
+    }
+  }
 }

--- a/resource/sites/beyond-hd.me/getSearchResult.js
+++ b/resource/sites/beyond-hd.me/getSearchResult.js
@@ -274,7 +274,7 @@
         }
         result = cell.text().trim();
       }
-      if(result == "")return null;
+      if(result === "")return null;
       return result;
     }
   }

--- a/resource/sites/blutopia.cc/config.json
+++ b/resource/sites/blutopia.cc/config.json
@@ -73,7 +73,6 @@
       }
     }
   },
-  "cdn": ["https://blutopia.cc/","https://blutopia.xyz/"],
   "searchEntryConfig": {
     "skipNonLatinCharacters": true
   }


### PR DESCRIPTION
一堆各种站可能都需要测一下,可能有些之前可以（应该没有吧，我自己手头没几个站），改了后反而不行的。

想法还是以blu为基准。

理论用title判断是最好的，但是blu目前支持中文了，这块判断略微会有些长，所以还是用图标了。

另外只做了seeding和complete的判断，其他的判断成本有点高，有空在弄好了