### PR TITLE
fix: fix a few configs have incorrect "downloaded" with "G"/"T" instead of "GB"/"TB"

### DIFF
--- a/resource/sites/pt.gtk.pw/config.json
+++ b/resource/sites/pt.gtk.pw/config.json
@@ -20,7 +20,7 @@
       "level": 2,
       "name": "Elite User",
       "interval": "8",
-      "downloaded": "120G",
+      "downloaded": "120GB",
       "ratio": "1.55",
       "privilege": "Elite User及以上用户封存账号后不会被删除。"
     },
@@ -28,7 +28,7 @@
       "level": 3,
       "name": "Crazy User",
       "interval": "15",
-      "downloaded": "300G",
+      "downloaded": "300GB",
       "ratio": "2.05",
       "privilege": "得到两个邀请名额；可以在做种/下载/发布的时候选择匿名模式。"
     },
@@ -36,7 +36,7 @@
       "level": 4,
       "name": "Insane User",
       "interval": "25",
-      "downloaded": "500G",
+      "downloaded": "500GB",
       "ratio": "2.55",
       "privilege": "可以查看普通日志。"
     },
@@ -44,7 +44,7 @@
       "level": 5,
       "name": "Veteran User",
       "interval": "40",
-      "downloaded": "750G",
+      "downloaded": "750GB",
       "ratio": "3.05",
       "privilege": "得到三个邀请名额；可以查看其它用户的评论、帖子历史。Veteran User及以上用户会永远保留账号。"
     },
@@ -52,7 +52,7 @@
       "level": 6,
       "name": "Extreme User",
       "interval": "60",
-      "downloaded": "1T",
+      "downloaded": "1TB",
       "ratio": "3.55",
       "privilege": "可以更新过期的外部信息；可以查看Extreme User论坛。"
     },
@@ -60,7 +60,7 @@
       "level": 7,
       "name": "Ultimate User",
       "interval": "80",
-      "downloaded": "1.5T",
+      "downloaded": "1.5TB",
       "ratio": "4.05",
       "privilege": "得到五个邀请名额。"
     },
@@ -68,7 +68,7 @@
       "level": 8,
       "name": "Nexus Master",
       "interval": "100",
-      "downloaded": "3T",
+      "downloaded": "3TB",
       "ratio": "4.55",
       "privilege": "得到十个邀请名额。"
     }

--- a/resource/sites/ubits.club/config.json
+++ b/resource/sites/ubits.club/config.json
@@ -22,7 +22,7 @@
         "level": 2,
         "name": "Elite User",
         "interval": "10",
-        "downloaded": "500G",
+        "downloaded": "500GB",
         "seedingPoints": "150000",
         "ratio": "3",
         "privilege": "Elite User及以上用户封存账号后不会被删除。"
@@ -31,7 +31,7 @@
         "level": 3,
         "name": "Crazy User",
         "interval": "15",
-        "downloaded": "800G",
+        "downloaded": "800GB",
         "seedingPoints": "300000",
         "ratio": "4",
         "privilege": "得到1个邀请名额；可以在做种/下载/发布的时候选择匿名模式。"
@@ -41,7 +41,7 @@
         "name": "Insane User",
         "seedingPoints": "650000",
         "interval": "20",
-        "downloaded": "1T",
+        "downloaded": "1TB",
         "ratio": "5",
         "privilege": "得到1个邀请名额；可以查看普通日志。"
       },
@@ -49,7 +49,7 @@
         "level": 5,
         "name": "Veteran User",
         "interval": "25",
-        "downloaded": "1.5T",
+        "downloaded": "1.5TB",
         "seedingPoints": "1000000",
         "ratio": "6",
         "privilege": "得到1个邀请名额；可以查看其它用户的评论、帖子历史。Veteran User及以上用户会永远保留账号。"
@@ -59,7 +59,7 @@
         "name": "Extreme User",
         "interval": "30",
         "seedingPoints": "2000000",
-        "downloaded": "2T",
+        "downloaded": "2TB",
         "ratio": "7",
         "privilege": "得到2个邀请名额；可以更新过期的外部信息；可以查看Extreme User论坛。"
       },
@@ -68,7 +68,7 @@
         "name": "Ultimate User",
         "interval": "40",
         "seedingPoints": "3000000",
-        "downloaded": "3T",
+        "downloaded": "3TB",
         "ratio": "8",
         "privilege": "得到3个邀请名额。"
       },
@@ -77,7 +77,7 @@
         "name": "Nexus Master",
         "seedingPoints": "5000000",
         "interval": "60",
-        "downloaded": "4T",
+        "downloaded": "4TB",
         "ratio": "10",
         "privilege": "得到4个邀请名额。"
       }

--- a/resource/sites/www.okpt.net/config.json
+++ b/resource/sites/www.okpt.net/config.json
@@ -23,7 +23,7 @@
         "level": 2,
         "name": "Elite User",
         "interval": "8",
-        "downloaded": "100G",
+        "downloaded": "100GB",
         "ratio": "2.5",
         "seedingPoints": "80000",
         "privilege": "没有新权限增加"
@@ -32,7 +32,7 @@
         "level": 3,
         "name": "Crazy User",
         "interval": "15",
-        "downloaded": "300G",
+        "downloaded": "300GB",
         "ratio": "3",
         "seedingPoints": "150000",
         "privilege": "可以在做种/下载/发布的时候选择匿名模式。"
@@ -41,7 +41,7 @@
         "level": 4,
         "name": "Insane User",
         "interval": "25",
-        "downloaded": "500G",
+        "downloaded": "500GB",
         "ratio": "3.5",
         "seedingPoints": "250000",
         "privilege": "可以查看普通日志。"
@@ -50,7 +50,7 @@
         "level": 5,
         "name": "Veteran User",
         "interval": "40",
-        "downloaded": "1T",
+        "downloaded": "1TB",
         "ratio": "4",
         "seedingPoints": "400000",
         "privilege": "可以查看其它用户的评论、帖子历史。"
@@ -59,7 +59,7 @@
         "level": 6,
         "name": "Extreme User",
         "interval": "60",
-        "downloaded": "2T",
+        "downloaded": "2TB",
         "ratio": "4.5",
         "seedingPoints": "600000",
         "privilege": "可以更新过期的外部信息。六级烧伤(Extreme User)及以上用户会永远保留账号。"
@@ -68,7 +68,7 @@
         "level": 7,
         "name": "Ultimate User",
         "interval": "80",
-        "downloaded": "5T",
+        "downloaded": "5TB",
         "ratio": "5",
         "seedingPoints": "800000",
         "privilege": "这个等级会永远保留账号。"
@@ -77,7 +77,7 @@
         "level": 8,
         "name": "Nexus Master",
         "interval": "100",
-        "downloaded": "10T",
+        "downloaded": "10TB",
         "ratio": "5.5",
         "seedingPoints": "1000000",
         "privilege": "这个等级会永远保留账号。"


### PR DESCRIPTION
有些站的升级增量计算有误。下载数据被无条件满足。

原因是因为有些站的“downloaded”配置是“500G”这样，而不是“500GB”这样。`fileSizetoLength`函数负责把这个配置转换成一个以字节为单位的整数。而这个函数里有一个正则表达式是期待“GB”而不是“B”。导致了这些配置被转换成了0。从而被无条件满足。修改配置即可修复。（"T" vs "TB"同理）

用`find . -name "config.json" | xargs -n1 grep -r "G\""`和`find . -name "config.json" | xargs -n1 grep -r "T\""`找了所有错误配置，都改好了。

复现步骤：
1. 找一个配置错误的站。或手动去掉“B”。
2. 同时，下载量不能满足当前等级升级所需的下载量。
3. 但是下载量却显示已满足。


![CleanShot 2024-08-04 at 21 50 18@2x](https://github.com/user-attachments/assets/8953e2a0-7935-44fb-b868-5358d1b6232b)
![CleanShot 2024-08-04 at 21 44 22@2x](https://github.com/user-attachments/assets/39d5579d-5528-4239-b9e5-85287c7dd115)

|Before|After|
| -------- | ------- |
|明明没有满足下载量，却认为我到了EU|正常计算下一级所需的下载增量|
|![CleanShot 2024-08-04 at 21 43 46@2x](https://github.com/user-attachments/assets/338bc372-e26e-44ec-a08e-e8bd73dc8095)|![CleanShot 2024-08-04 at 21 53 45@2x](https://github.com/user-attachments/assets/5c6c3f2d-a232-4695-83ff-c1b31da46580)|
