### PR TITLE
fix(pter): fix pter uploads count

### DIFF
--- a/resource/sites/pterclub.com/config.json
+++ b/resource/sites/pterclub.com/config.json
@@ -183,11 +183,11 @@
     },
     "userUploadedTorrents": {
       "prerequisites": "!user.uploads",
-      "page": "/torrents.php?incldead=1&spstate=0&inclbookmarked=0&check=checked&search=$user.name$&search_area=3&search_mode=3",
+      "page": "/getusertorrentlist.php?do_ajax=1&userid=$user.id$&type=uploaded",
       "fields": {
         "uploads": {
-          "selector": ["p.np-pager:first b:last"],
-          "filters": ["query.text().replace(/,/g,'').split('-')", "(query && query.length > 1) ? parseInt(query[1]) : 0"]
+          "selector": ["b:first"],
+          "filters": ["query.text()"]
         }
       }
     }


### PR DESCRIPTION
猫站
刚发了两个种子，PTPP还是显示我没有发种。
在背景页看PTPP在用我的用户名搜种子，没有搜到结果。我推测可能是因为我发的是匿名种子。匿名种子即使是自己也搜不到。
反正用户页有一个更可靠的ajax可以用。改过去试试。


|before|after|
|---|---|
|这个是用用户名搜的。没有搜到。<br />![CleanShot 2024-08-07 at 23 50 04@2x](https://github.com/user-attachments/assets/64dc8752-2f01-489e-8a28-7fbf0be8f6de) <br /> <br /> 没有读到上传种子数<br />![CleanShot 2024-08-07 at 23 49 31@2x](https://github.com/user-attachments/assets/7092327b-0d5d-4c6d-8524-b87936f81c9f)|这个是用户页面的ajax。<br />![CleanShot 2024-08-07 at 23 50 47@2x](https://github.com/user-attachments/assets/58ba9e70-c983-4166-851b-cf7ed5b077d7) <br /> <br />正确读到了2个上传的种子 <br />![CleanShot 2024-08-08 at 00 05 28@2x](https://github.com/user-attachments/assets/872671b9-5894-4114-849d-4c8dc5a2eda8)|