### PR TITLE
fix(ptvicomo): 修复搜索种子详情不显示

### DIFF
--- a/resource/sites/ptvicomo.net/config.json
+++ b/resource/sites/ptvicomo.net/config.json
@@ -162,6 +162,13 @@
         "appendQueryString": "&search_area=1"
       }
     ],
+    "fieldIndex": {
+      "time": 2,
+      "size": 3,
+      "seeders": 4,
+      "leechers": 5,
+      "completed": 6
+    }, 
     "fieldSelector": {
       "progress": {
         "selector": [


### PR DESCRIPTION
#1914
#1833
![image](https://github.com/user-attachments/assets/126c7bb2-6b62-4b63-9ba7-4a96ace6a553)