### PR TITLE
fix(fsm): send torrent in detail page

### DIFF
--- a/resource/sites/fsm.name/config.json
+++ b/resource/sites/fsm.name/config.json
@@ -21,19 +21,9 @@
   ],
   "plugins": [
     {
-      "name": "种子详情页面",
-      "pages": [
-        "/Torrents/details"
-      ],
-      "scripts": [
-        "/schemas/NexusPHP/common.js",
-        "/schemas/Common/details.js"
-      ]
-    },
-    {
       "name": "种子列表",
       "pages": [
-        "/Torrents$"
+        "/Torrents"
       ],
       "scripts": [
         "/schemas/NexusPHP/common.js",
@@ -165,16 +155,8 @@
       }
     },
     "common": {
-      "page": "/api/Torrents",
+      "page": "/Torrents",
       "fields": {
-        "downloadURL": {
-          "selector": [
-            "a[href*='/Torrents/download']"
-          ],
-          "filters": [
-            "query.attr('href')"
-          ]
-        },
         "size": {
           "selector": [
             "div.visible-xs:contains('种子大小') + div"


### PR DESCRIPTION
详情页面只有一个下载按钮，可以与列表共用一个插件来实现推送种子，解决了需要手动设置 APICDN 的问题。