### PR TITLE
fix(milkie): auth with api key

### DIFF
--- a/resource/sites/milkie.cc/config.json
+++ b/resource/sites/milkie.cc/config.json
@@ -33,7 +33,7 @@
     "parseScriptFile": "getSearchResult.js",
     "keepOriginKey": true,
     "headers": {
-      "Authorization": "Bearer $site.authToken$"
+      "x-milkie-auth": "$site.authToken$"
     }
   },
   "searchEntry": [
@@ -48,7 +48,7 @@
       "dataType": "json",
       "requestMethod": "GET",
       "headers": {
-        "Authorization": "Bearer $site.authToken$"
+        "x-milkie-auth": "$site.authToken$"
       },
       "fields": {
         "name": {

--- a/resource/sites/milkie.cc/getSearchResult.js
+++ b/resource/sites/milkie.cc/getSearchResult.js
@@ -30,7 +30,7 @@
           let data = {
             title: group.releaseName,
             link: `${site.url}/browse/${group.id}`,
-            url: `${site.url}/api/v1/torrents/${group.id}/torrent?key=${encodeURIComponent(site.passkey)}`,
+            url: `${site.url}/api/v1/torrents/${group.id}/torrent?key=${encodeURIComponent(site.authToken)}`,
             size: group.size,
             time: Date(group.createdAt),
             seeders: group.seeders,


### PR DESCRIPTION
感谢 https://github.com/pt-plugins/PT-Plugin-Plus/pull/1985#issuecomment-2326383497 的提醒，现在只需将 https://milkie.cc/settings/security 里获取的 API key 填入鉴权 Token 即可实现用户数据获取及搜索推送种子。