### PR TITLE
fix(tjupt): 站点搜索范围功能失效

### DIFF
--- a/resource/sites/tjupt.org/config.json
+++ b/resource/sites/tjupt.org/config.json
@@ -105,64 +105,69 @@
       "enabled": true
     },
     {
-      "queryString": "cat401=1",
+      "queryString": "cat=401",
       "name": "电影",
       "enabled": false
     },
     {
-      "queryString": "cat403=1",
+      "queryString": "cat=402",
+      "name": "剧集",
+      "enabled": false
+    },
+    {
+      "queryString": "cat=403",
       "name": "综艺",
       "enabled": false
     },
     {
-      "queryString": "cat404=1",
+      "queryString": "cat=404",
       "name": "资料",
       "enabled": false
     },
     {
-      "queryString": "cat405=1",
+      "queryString": "cat=405",
       "name": "动漫",
       "enabled": false
     },
     {
-      "queryString": "cat406=1",
+      "queryString": "cat=406",
       "name": "音乐",
       "enabled": false
     },
     {
-      "queryString": "cat407=1",
-      "name": "音乐",
+      "queryString": "cat=407",
+      "name": "体育",
       "enabled": false
     },
     {
-      "queryString": "cat408=1",
+      "queryString": "cat=408",
       "name": "软件",
       "enabled": false
     },
     {
-      "queryString": "cat409=1",
+      "queryString": "cat=409",
       "name": "游戏",
       "enabled": false
     },
     {
-      "queryString": "cat411=1",
+      "queryString": "cat=411",
       "name": "纪录片",
       "enabled": false
     },
     {
-      "queryString": "cat412=1",
+      "queryString": "cat=412",
       "name": "移动视频",
       "enabled": false
     },
     {
-      "queryString": "cat410=1",
+      "queryString": "cat=410",
       "name": "其他",
       "enabled": false
     }
   ],
   "categories": [{
     "entry": "*",
-    "result": "&cat$id$=1",
+    "result": "&cat=$id$",
     "category": [{
         "id": 401,
         "name": "电影"

--- a/resource/sites/tjupt.org/config.json
+++ b/resource/sites/tjupt.org/config.json
@@ -167,7 +167,7 @@
   ],
   "categories": [{
     "entry": "*",
-    "result": "&cat=$id$",
+    "result": "&cat[]=$id$",
     "category": [{
         "id": 401,
         "name": "电影"


### PR DESCRIPTION
本PR修复以下问题：
编辑站点中指定搜索范围失效；
搜索方案中指定站点的搜索范围失效。
两者都会返回全部分类的结果。