### PR TITLE
fix(jpop): 当关闭 torrent grouping 时，从搜索结果中获取种子报错

### DIFF
--- a/resource/sites/jpopsuki.eu/getSearchResult.js
+++ b/resource/sites/jpopsuki.eu/getSearchResult.js
@@ -141,6 +141,13 @@ if (!"".getQueryString) {
             case row.is(".torrent_redline"):
               albumRow = row;
               albumTitle = title;
+              // 当在 Profile 里关闭 torrent grouping 时，补全单元格以让索引位置生效
+              if (cells.eq(0).text().trim() !== "") {
+                let tmpRow = row.clone().get(0);
+                tmpRow.insertCell(0);
+                cells = $(tmpRow).find(">td");
+                fieldIndex.category = 0;
+              }
               break;
 
             default:


### PR DESCRIPTION
当在 Profile 里关闭 torrent grouping 时，从搜索结果中获取种子报错。