### PR TITLE
fix：PTPP 使用 IMDB 编码搜索 Lolicon PT 的问题

### DIFF
--- a/resource/sites/share.ilolicon.com/config.json
+++ b/resource/sites/share.ilolicon.com/config.json
@@ -171,7 +171,7 @@
   ],
   "searchEntryConfig": {
     "merge": true,
-    "skipIMDbId": true,
+    "skipIMDbId": false,
     "fieldSelector": {
       "progress": {
         "selector": [


### PR DESCRIPTION
- 更新配置以确保 Lolicon PT 搜索的兼容性。
- 测试并确认功能正常。