### PR TITLE
fix(hhanclub): remove "[新]" in title when getting search results

### DIFF
--- a/resource/sites/hhanclub.top/getSearchResult.js
+++ b/resource/sites/hhanclub.top/getSearchResult.js
@@ -52,6 +52,7 @@
         // 遍历数据行
         for (let index = 0; index < rows.length; index++) {
           const row = rows.eq(index);
+          row.find(".torrent-info-text-name .new").remove();
           let title = row.find(".torrent-info-text-name");
           if (title.length == 0) {
             continue;


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/e9fedbc8-67aa-48b0-8f53-c3d69893968a" width="60%">
