### PR TITLE
fe: 如果有未完成的签到，显示有未读消息的提示。

### DIFF
--- a/resource/schemas/NexusPHP/config.json
+++ b/resource/schemas/NexusPHP/config.json
@@ -81,6 +81,10 @@
         "messageCount": {
           "selector": ["td[style*='background: red'] a[href*='messages.php']", "div[style*='background: red'] a[href*='messages.php']"],
           "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        },
+        "pendingCheckins": {
+          "selector": ["a[class*='faqlink']"],
+          "filters": ["query.text().match(/(签到得)/)", "(query && query.length>=1)?1:0"]
         }
       }
     },

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -93,10 +93,10 @@
             <v-badge color="red messageCount" overlap>
               <template v-slot:badge v-if="
                 !props.item.disableMessageCount &&
-                props.item.user.messageCount > 0
+                (props.item.user.messageCount > 0 || props.item.user.pendingCheckins > 0)
               " :title="$t('home.newMessage')">
                 {{
-                    props.item.user.messageCount > 10
+                    (props.item.user.messageCount > 10 || props.item.user.messageCount == 0)
                       ? ""
                       : props.item.user.messageCount
                 }}
@@ -655,7 +655,7 @@ export default Vue.extend({
     },
     allUnReadMsgSites() {
       // @ts-ignore
-      return this.allSitesSorted.filter((site: Site) => !site.disableMessageCount && ((site.user?.messageCount || 0) > 0))
+      return this.allSitesSorted.filter((site: Site) => !site.disableMessageCount && ((site.user?.messageCount || 0) > 0 || (site.user?.pendingCheckins || 0) > 0))
     },
     allTaggedSites() {
       // @ts-ignore

--- a/src/options/views/UserDataTimeline.vue
+++ b/src/options/views/UserDataTimeline.vue
@@ -331,7 +331,8 @@ export default Vue.extend({
         res = res.concat(allUnTaggedSites)
       }
       if (tags.includes(ETagType.unReadMsg)) {
-        let allUnReadMsgSites = sites.filter((site: Site) => (site.user?.messageCount || 0) > 0)
+        // 有未读消息或签到消息
+        let allUnReadMsgSites = sites.filter((site: Site) => (site.user?.messageCount || 0) > 0 || (site.user?.pendingCheckins || 0) > 0)
         res = res.concat(allUnReadMsgSites)
       }
       if (tags.includes(ETagType.statusError)) {


### PR DESCRIPTION
获取是否有未完成签到的信息。注，旨在获取信息。
如果有未完成的签到，显示跟有未读消息一样的提示：1. 顶部一键打开有未读消息的站点，2. 站点图标上显示一个圆点。
如果未读消息数量在(0,10)之间，还是会显示未读消息数量，否则只有一个红点。

只适配了默认NexusPHP模板。如果这个方案可以接受，会继续适配一些主流站点。

效果图：
![CleanShot 2024-10-19 at 13 56 49@2x](https://github.com/user-attachments/assets/35234313-be76-45b6-a104-410ca8065446)
