### PR TITLE
fe: 如果有未完成的签到，显示有未读消息的提示。

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -178,6 +178,7 @@
       "selectColumns": "Select Columns",
       "selectedTags": "Selected Tags",
       "week": "Expressed in weeks",
+      "showNotAttended": "Show not attended",
       "timeline": "Time line",
       "settings": "Settings",
       "statistic": "Statistic",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -175,6 +175,7 @@
       "selectColumns": "过滤列",
       "selectedTags": "标签分组过滤",
       "week": "时间显示为周数",
+      "showNotAttended": "未签到的站点",
       "timeline": "时间轴",
       "settings": "参数",
       "statistic": "数据图表",

--- a/resource/schemas/NexusPHP/config.json
+++ b/resource/schemas/NexusPHP/config.json
@@ -81,6 +81,10 @@
         "messageCount": {
           "selector": ["td[style*='background: red'] a[href*='messages.php']", "div[style*='background: red'] a[href*='messages.php']"],
           "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        },
+        "notAttended": {
+          "selector": ["a[href*='attendance.php']", "input#modalBtn", "a[class*='faqlink']", "a#showup", "a[href*='bakatest.php']"],
+          "filters": ["(query.text() || (query.length > 0 && query[0].outerHTML) || '').match(/(签到得|簽到得|立即签到|每日签到|每日打卡|\\[签到)/)", "(query && query.length>=1)?1:0"]
         }
       }
     },

--- a/resource/sites/cyanbug.net/config.json
+++ b/resource/sites/cyanbug.net/config.json
@@ -166,6 +166,10 @@
             "query.text().match(/(\\d+)/)",
             "(query && query.length>=2)?parseInt(query[1]):0"
           ]
+        },
+        "notAttended": {
+          "selector": ["a[href*='attendance.php']"],
+          "filters": ["query.text().match(/(签到得|簽到得|\\[Attend)/)", "(query && query.length>=1)?1:0"]
         }
       }
     },

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -51,6 +51,8 @@
                 @change="updateViewOptions"></v-switch>
               <v-switch color="success" v-model="showLastUpdateTimeAsRelativeTime" :label="$t('home.showLastUpdateTimeAsRelativeTime')"
                 @change="updateViewOptions"></v-switch>
+              <v-switch color="success" v-model="showNotAttended" :label="$t('home.showNotAttended')"
+                @change="updateViewOptions"></v-switch>
             </v-container>
           </v-card>
         </v-menu>
@@ -91,12 +93,13 @@
           <!-- 站点 -->
           <td v-if="showColumn('name')" class="center">
             <v-badge color="red messageCount" overlap>
+              <!-- 有未读消息或签到消息。未读消息可以在站点设置里关闭。签到消息可以在本页顶部设置里关闭。 -->
               <template v-slot:badge v-if="
-                !props.item.disableMessageCount &&
-                props.item.user.messageCount > 0
+                (!props.item.disableMessageCount && props.item.user.messageCount > 0 ) || 
+                (showNotAttended && props.item.user.notAttended > 0)
               " :title="$t('home.newMessage')">
                 {{
-                    props.item.user.messageCount > 10
+                    (props.item.user.messageCount > 10 || props.item.user.messageCount == 0)
                       ? ""
                       : props.item.user.messageCount
                 }}
@@ -605,6 +608,7 @@ export default Vue.extend({
       showHnR: true,
       showLastUpdateTimeAsRelativeTime:true,
       showWeek: false,
+      showNotAttended: false,
     };
   },
   created() {
@@ -655,7 +659,10 @@ export default Vue.extend({
     },
     allUnReadMsgSites() {
       // @ts-ignore
-      return this.allSitesSorted.filter((site: Site) => !site.disableMessageCount && ((site.user?.messageCount || 0) > 0))
+      return this.allSitesSorted.filter((site: Site) => 
+        (!site.disableMessageCount && (site.user?.messageCount || 0) > 0) || 
+        (this.showNotAttended && (site.user?.notAttended || 0) > 0)
+      )
     },
     allTaggedSites() {
       // @ts-ignore
@@ -786,6 +793,7 @@ export default Vue.extend({
         showHnR: true,
         showLastUpdateTimeAsRelativeTime:true,
         showWeek: false,
+        showNotAttended: false,
         selectedHeaders: this.selectedHeaders,
       });
       Object.assign(this, viewOptions);
@@ -1329,6 +1337,7 @@ export default Vue.extend({
           showHnR: this.showHnR,
           showLastUpdateTimeAsRelativeTime: this.showLastUpdateTimeAsRelativeTime,
           showWeek: this.showWeek,
+          showNotAttended: this.showNotAttended,
           selectedHeaders: this.selectedHeaders,
           selectedTags: this.selectedTags,
         },

--- a/src/options/views/UserDataTimeline.vue
+++ b/src/options/views/UserDataTimeline.vue
@@ -331,7 +331,8 @@ export default Vue.extend({
         res = res.concat(allUnTaggedSites)
       }
       if (tags.includes(ETagType.unReadMsg)) {
-        let allUnReadMsgSites = sites.filter((site: Site) => (site.user?.messageCount || 0) > 0)
+        // 有未读消息或签到消息
+        let allUnReadMsgSites = sites.filter((site: Site) => (site.user?.messageCount || 0) > 0 || (site.user?.notAttended || 0) > 0)
         res = res.concat(allUnReadMsgSites)
       }
       if (tags.includes(ETagType.statusError)) {


### PR DESCRIPTION
获取是否有未完成签到的信息。注，旨在获取信息。
如果有未完成的签到，显示跟有未读消息一样的提示：1. 顶部一键打开有未读消息的站点，2. 站点图标上显示一个圆点，3. 未读消息的标签筛选。
如果未读消息数量在(0,10)之间，还是会显示未读消息数量，否则只有一个红点。
在数据页面的选项里面可以打开或者关闭未签到网站的提示。默认关闭。这个开关在检测显示未读消息开关的地方也检测。

只适配了默认NexusPHP模板。如果这个方案可以接受，会继续适配一些主流站点。

效果图：
![CleanShot 2024-10-19 at 13 56 49@2x](https://github.com/user-attachments/assets/35234313-be76-45b6-a104-410ca8065446)

![CleanShot 2024-10-19 at 20 53 27@2x](https://github.com/user-attachments/assets/c30b62cb-6d65-4df7-91d4-5c0ed045a992)
