### PR TITLE
fix:添加站点窗口自动关闭

### DIFF
--- a/src/options/views/settings/Sites/Add.vue
+++ b/src/options/views/settings/Sites/Add.vue
@@ -3,8 +3,8 @@
     <v-snackbar :value="haveError" top :timeout="3000" color="error">{{
       $t("settings.sites.add.validMsg")
     }}</v-snackbar>
-    <v-dialog v-model="show" max-width="800">
-      <v-card>
+    <v-dialog v-model="show" max-width="800" :persistent="ClickOutSide" >
+      <v-card  @mousedown="ClickOutSide = true" @mouseup="ClickOutSide = false" @mouseenter="ClickOutSide = false">
         <v-toolbar dark color="blue-grey darken-2">
           <v-toolbar-title>{{
             $t("settings.sites.add.title")
@@ -163,7 +163,8 @@ export default Vue.extend({
       valid: false,
       isCustom: false,
       newData: {} as Site,
-      haveError: false
+      haveError: false,
+      ClickOutSide: false
     };
   },
   props: {


### PR DESCRIPTION
在添加站点时，鼠标超过弹窗会自动关闭，这里使用简单的办法解决这个问题，并且保留原有交互

以下是效果预览

正常操作时候，一切正常
![1](https://github.com/user-attachments/assets/3ccc9827-120d-4462-80a1-debab8c12805)

如果在操作中鼠标超出弹窗，会设置弹窗无法关闭
![2](https://github.com/user-attachments/assets/ce85271f-c6a1-42f0-ac06-a163dd99dc5f)

鼠标返回弹窗，即可恢复正常状态
![3](https://github.com/user-attachments/assets/fbf01d6a-1e50-48df-a6d7-b9c4fa29cc29)
