### PR TITLE
fix: 更新猪猪等级规则中VU的下载量

### DIFF
--- a/resource/sites/piggo.me/config.json
+++ b/resource/sites/piggo.me/config.json
@@ -71,7 +71,7 @@
         "level": "5",
         "name": "猪妖(Veteran User)",
         "interval": "40",
-        "downloaded": "3TB",
+        "downloaded": "2TB",
         "ratio": "4",
         "seedingPoints": "400000",
         "privilege": "得到两个永久邀请名额；可以查看其它用户的评论、帖子历史。"


### PR DESCRIPTION
修改猪猪等级规则中VU的下载量错误

![image](https://github.com/user-attachments/assets/da78da3b-480c-4a87-88e7-5b541fedb418)
