### PR TITLE
fix: 修复 monikadesign.uk 时魔数据显示为分钟魔的问题

### DIFF
--- a/resource/sites/monikadesign.uk/config.json
+++ b/resource/sites/monikadesign.uk/config.json
@@ -98,6 +98,16 @@
           "filters": ["query ? new URL(query).pathname : null"]
         }
       }
+    },
+    "bonusExtendInfo": {
+      "prerequisites": "!(!user.bonusPage)",
+      "page": "$user.bonusPage$",
+      "fields": {
+        "bonusPerHour": {
+          "selector": [".panelV2 dl.key-value dd:nth(3)"],
+          "filters": ["parseFloat(query.text().replace(/,/g,'').match(/[\\d.]+/)[0])"]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## 内容说明

修复 monikadesign.uk 时魔数据显示为分钟魔的问题

修复后

![422673248-ac03d029-fb1f-4c88-b5da-4d2a072d4bca](https://github.com/user-attachments/assets/ec025ae3-8ef0-40cd-937e-dd7a1fecb5f7)
![422673595-e9264110-1df9-4be8-855b-a6c0c14dfdb2](https://github.com/user-attachments/assets/bd9c5022-3786-4763-aa96-24f662ec44af)
