### PR TITLE
修复馒头时魔不显示

### DIFF
--- a/resource/sites/xp.m-team.cc/config.json
+++ b/resource/sites/xp.m-team.cc/config.json
@@ -444,7 +444,6 @@
       "page": "/api/tracker/mybonus",
       "dataType": "json",
       "requestMethod": "POST",
-      "requestContentType": "application/json",
       "headers": {
         "x-api-key": "$site.authToken$"
       },


### PR DESCRIPTION
馒头今天调整了API接口，当Content-Type为json且请求体为空时会返回”请求参数错误“。
解决方法：对于没有请求体的时魔查询接口，不要指定Content-Type为json